### PR TITLE
Minor changes in CMakeLists.txt

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -13,6 +13,7 @@ jobs:
         name:
         - Linux-GNU
         - Linux-Clang
+        - Linux-Clang-libc++
         - MacOS-Clang
         - Windows-VisualStudio
         build_type: [ Debug ]
@@ -25,6 +26,11 @@ jobs:
           compiler: clang++-9
           os: ubuntu-16.04
           dep-install: sudo apt-get install -y cmake doxygen graphviz clang
+        - name: Linux-Clang-libc++
+          compiler: clang++-9
+          os: ubuntu-16.04
+          dep-install: sudo apt-get install -y cmake doxygen graphviz clang libc++-dev
+          build_with_libcpp: ON
         - name: MacOS-Clang
           os: macos-10.15
           compiler: clang++
@@ -43,6 +49,7 @@ jobs:
       BUILD_TYPE: ${{ matrix.build_type }}
       CXX: ${{ matrix.compiler }}
       CTEST_OUTPUT_ON_FAILURE: 1
+      BUILD_WITH_LIBCPP: ${{matrix.build_with_cpp}}
     # The CMake configure and build commands are platform agnostic and should work equally
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -28,7 +28,7 @@ jobs:
         #   dep-install: sudo apt-get install -y cmake doxygen graphviz clang
         - name: Linux-Clang-libc++
           compiler: clang++-9
-          os: ubuntu-latest
+          os: ubuntu-18.04
           dep-install: sudo apt-get install -y cmake doxygen graphviz clang libc++abi-9-dev  libc++-9-dev
           build_with_libcpp: ON
           # # special_symlink: ln -s /usr/include/libcxxabi/__cxxabi_config.h /usr/include/c++/v1/__cxxabi_config.h

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -31,7 +31,7 @@ jobs:
           os: ubuntu-latest
           dep-install: sudo apt-get install -y cmake doxygen graphviz clang libc++-dev libc++abi-dev
           build_with_libcpp: ON
-          special_symlink: ln -s /usr/include/libcxxabi/__cxxabi_config.h /usr/include/c++/v1/__cxxabi_config.h
+          # # special_symlink: ln -s /usr/include/libcxxabi/__cxxabi_config.h /usr/include/c++/v1/__cxxabi_config.h
         # - name: MacOS-Clang
         #   os: macos-10.15
         #   compiler: clang++
@@ -83,7 +83,7 @@ jobs:
       working-directory: ${{github.workspace}}/build
       shell: bash
       # Execute the build.  You can specify a specific target with "--target <NAME>"
-      run: ${{ matrix.special_symlink }} ;  cmake --build . --config $BUILD_TYPE
+      run: cmake --build . --config $BUILD_TYPE
 
     - name: Test
       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -14,8 +14,8 @@ jobs:
         - Linux-GNU
         - Linux-Clang
         - Linux-Clang-libc++
-        - MacOS-Clang
-        - Windows-VisualStudio
+        # - MacOS-Clang
+        # - Windows-VisualStudio
         build_type: [ Debug ]
         include:
         - name: Linux-GNU
@@ -31,12 +31,12 @@ jobs:
           os: ubuntu-16.04
           dep-install: sudo apt-get install -y cmake doxygen graphviz clang libc++-dev
           build_with_libcpp: ON
-        - name: MacOS-Clang
-          os: macos-10.15
-          compiler: clang++
-        - name: Windows-VisualStudio
-          os: windows-2019
-          compiler: msvs
+        # - name: MacOS-Clang
+        #   os: macos-10.15
+        #   compiler: clang++
+        # - name: Windows-VisualStudio
+        #   os: windows-2019
+        #   compiler: msvs
         - name: Release
           os: ubuntu-20.04
           compiler: g++-10
@@ -77,7 +77,7 @@ jobs:
       # Note the current convention is to use the -S and -B options here to specify source 
       # and build directories, but this is only available with CMake 3.13 and higher.  
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE ${{ matrix.generator }} -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+      run: cmake $GITHUB_WORKSPACE ${{ matrix.generator }} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_WITH_CPP=$BUILD_WITH_CPP
     - name: Build
       working-directory: ${{github.workspace}}/build
       shell: bash

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         name:
         # - Linux-GNU
-        - Linux-Clang
+        # - Linux-Clang
         - Linux-Clang-libc++
         # - MacOS-Clang
         # - Windows-VisualStudio
@@ -22,14 +22,14 @@ jobs:
         #   compiler: g++-9
         #   os: ubuntu-18.04
         #   dep-install: sudo apt-get install -y cmake doxygen graphviz
-        - name: Linux-Clang
-          compiler: clang++-9
-          os: ubuntu-16.04
-          dep-install: sudo apt-get install -y cmake doxygen graphviz clang
+        # - name: Linux-Clang
+        #   compiler: clang++-9
+        #   os: ubuntu-16.04
+        #   dep-install: sudo apt-get install -y cmake doxygen graphviz clang
         - name: Linux-Clang-libc++
           compiler: clang++-9
           os: ubuntu-latest
-          dep-install: sudo apt-get install -y cmake doxygen graphviz clang libc++-dev libc++abi-dev
+          dep-install: sudo apt-get install -y cmake doxygen graphviz clang libc++abi-9-dev  libc++-9-dev
           build_with_libcpp: ON
           # # special_symlink: ln -s /usr/include/libcxxabi/__cxxabi_config.h /usr/include/c++/v1/__cxxabi_config.h
         # - name: MacOS-Clang

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -49,7 +49,7 @@ jobs:
       BUILD_TYPE: ${{ matrix.build_type }}
       CXX: ${{ matrix.compiler }}
       CTEST_OUTPUT_ON_FAILURE: 1
-      BUILD_WITH_LIBCPP: ${{matrix.build_with_cpp}}
+      BUILD_WITH_LIBCPP: ${{ matrix.build_with_libcpp }}
     # The CMake configure and build commands are platform agnostic and should work equally
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -28,7 +28,7 @@ jobs:
           dep-install: sudo apt-get install -y cmake doxygen graphviz clang
         - name: Linux-Clang-libc++
           compiler: clang++-9
-          os: ubuntu-16.04
+          os: ubuntu-latest
           dep-install: sudo apt-get install -y cmake doxygen graphviz clang libc++-dev libc++abi-dev
           build_with_libcpp: ON
           special_symlink: ln -s /usr/include/libcxxabi/__cxxabi_config.h /usr/include/c++/v1/__cxxabi_config.h

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         name:
         # - Linux-GNU
-        # - Linux-Clang
+        - Linux-Clang
         - Linux-Clang-libc++
         # - MacOS-Clang
         # - Windows-VisualStudio
@@ -22,10 +22,10 @@ jobs:
         #   compiler: g++-9
         #   os: ubuntu-18.04
         #   dep-install: sudo apt-get install -y cmake doxygen graphviz
-        # - name: Linux-Clang
-        #   compiler: clang++-9
-        #   os: ubuntu-16.04
-        #   dep-install: sudo apt-get install -y cmake doxygen graphviz clang
+        - name: Linux-Clang
+          compiler: clang++-9
+          os: ubuntu-16.04
+          dep-install: sudo apt-get install -y cmake doxygen graphviz clang
         - name: Linux-Clang-libc++
           compiler: clang++-9
           os: ubuntu-16.04
@@ -77,7 +77,7 @@ jobs:
       # Note the current convention is to use the -S and -B options here to specify source 
       # and build directories, but this is only available with CMake 3.13 and higher.  
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: echo $BUILD_WITH_LIBCPP &&  cmake $GITHUB_WORKSPACE ${{ matrix.generator }} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_WITH_CPP=$BUILD_WITH_LIBCPP
+      run: echo $BUILD_WITH_LIBCPP &&  cmake $GITHUB_WORKSPACE ${{ matrix.generator }} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_WITH_LIBCPP=$BUILD_WITH_LIBCPP
     - name: Build
       working-directory: ${{github.workspace}}/build
       shell: bash

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -11,38 +11,37 @@ jobs:
     strategy:
       matrix:
         name:
-        # - Linux-GNU
-        # - Linux-Clang
+        - Linux-GNU
+        - Linux-Clang
         - Linux-Clang-libc++
         # - MacOS-Clang
-        # - Windows-VisualStudio
+        - Windows-VisualStudio
         build_type: [ Debug ]
         include:
-        # - name: Linux-GNU
-        #   compiler: g++-9
-        #   os: ubuntu-18.04
-        #   dep-install: sudo apt-get install -y cmake doxygen graphviz
-        # - name: Linux-Clang
-        #   compiler: clang++-9
-        #   os: ubuntu-16.04
-        #   dep-install: sudo apt-get install -y cmake doxygen graphviz clang
+        - name: Linux-GNU
+          compiler: g++-9
+          os: ubuntu-18.04
+          dep-install: sudo apt-get install -y cmake doxygen graphviz
+        - name: Linux-Clang
+          compiler: clang++-9
+          os: ubuntu-16.04
+          dep-install: sudo apt-get install -y cmake doxygen graphviz clang
         - name: Linux-Clang-libc++
           compiler: clang++-9
           os: ubuntu-18.04
           dep-install: sudo apt-get install -y cmake doxygen graphviz clang libc++abi-9-dev  libc++-9-dev
           build_with_libcpp: ON
-          # # special_symlink: ln -s /usr/include/libcxxabi/__cxxabi_config.h /usr/include/c++/v1/__cxxabi_config.h
         # - name: MacOS-Clang
         #   os: macos-10.15
         #   compiler: clang++
-        # - name: Windows-VisualStudio
-        #   os: windows-2019
-        #   compiler: msvs
-        # - name: Release
-        #   os: ubuntu-20.04
-        #   compiler: g++-10
-        #   dep-install: sudo apt-get install -y cmake doxygen graphviz
-        #   build_type: Release
+        - name: Windows-VisualStudio
+          os: windows-2019
+          compiler: msvs
+        - name: Release
+          os: ubuntu-20.04
+          compiler: g++-10
+          dep-install: sudo apt-get install -y cmake doxygen graphviz
+          build_type: Release
 
 
     env:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -11,37 +11,37 @@ jobs:
     strategy:
       matrix:
         name:
-        - Linux-GNU
-        - Linux-Clang
+        # - Linux-GNU
+        # - Linux-Clang
         - Linux-Clang-libc++
         # - MacOS-Clang
         # - Windows-VisualStudio
         build_type: [ Debug ]
         include:
-        - name: Linux-GNU
-          compiler: g++-9
-          os: ubuntu-18.04
-          dep-install: sudo apt-get install -y cmake doxygen graphviz
-        - name: Linux-Clang
-          compiler: clang++-9
-          os: ubuntu-16.04
-          dep-install: sudo apt-get install -y cmake doxygen graphviz clang
+        # - name: Linux-GNU
+        #   compiler: g++-9
+        #   os: ubuntu-18.04
+        #   dep-install: sudo apt-get install -y cmake doxygen graphviz
+        # - name: Linux-Clang
+        #   compiler: clang++-9
+        #   os: ubuntu-16.04
+        #   dep-install: sudo apt-get install -y cmake doxygen graphviz clang
         - name: Linux-Clang-libc++
           compiler: clang++-9
           os: ubuntu-16.04
           dep-install: sudo apt-get install -y cmake doxygen graphviz clang libc++-dev
-          build_with_libcpp: "on"
+          build_with_libcpp: ON
         # - name: MacOS-Clang
         #   os: macos-10.15
         #   compiler: clang++
         # - name: Windows-VisualStudio
         #   os: windows-2019
         #   compiler: msvs
-        - name: Release
-          os: ubuntu-20.04
-          compiler: g++-10
-          dep-install: sudo apt-get install -y cmake doxygen graphviz
-          build_type: Release
+        # - name: Release
+        #   os: ubuntu-20.04
+        #   compiler: g++-10
+        #   dep-install: sudo apt-get install -y cmake doxygen graphviz
+        #   build_type: Release
 
 
     env:
@@ -77,7 +77,7 @@ jobs:
       # Note the current convention is to use the -S and -B options here to specify source 
       # and build directories, but this is only available with CMake 3.13 and higher.  
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: echo $BUILD_WITH_CPP &&  cmake $GITHUB_WORKSPACE ${{ matrix.generator }} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_WITH_CPP=$BUILD_WITH_CPP
+      run: echo $BUILD_WITH_LIBCPP &&  cmake $GITHUB_WORKSPACE ${{ matrix.generator }} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_WITH_CPP=$BUILD_WITH_LIBCPP
     - name: Build
       working-directory: ${{github.workspace}}/build
       shell: bash

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -29,7 +29,7 @@ jobs:
         - name: Linux-Clang-libc++
           compiler: clang++-9
           os: ubuntu-16.04
-          dep-install: sudo apt-get install -y cmake doxygen graphviz clang libc++-dev
+          dep-install: sudo apt-get install -y cmake doxygen graphviz clang libc++-dev libc++abi-dev
           build_with_libcpp: ON
         # - name: MacOS-Clang
         #   os: macos-10.15

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -30,7 +30,7 @@ jobs:
           compiler: clang++-9
           os: ubuntu-16.04
           dep-install: sudo apt-get install -y cmake doxygen graphviz clang libc++-dev
-          build_with_libcpp: ON
+          build_with_libcpp: "on"
         # - name: MacOS-Clang
         #   os: macos-10.15
         #   compiler: clang++
@@ -77,7 +77,7 @@ jobs:
       # Note the current convention is to use the -S and -B options here to specify source 
       # and build directories, but this is only available with CMake 3.13 and higher.  
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE ${{ matrix.generator }} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_WITH_CPP=$BUILD_WITH_CPP
+      run: echo $BUILD_WITH_CPP &&  cmake $GITHUB_WORKSPACE ${{ matrix.generator }} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_WITH_CPP=$BUILD_WITH_CPP
     - name: Build
       working-directory: ${{github.workspace}}/build
       shell: bash

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -31,6 +31,7 @@ jobs:
           os: ubuntu-16.04
           dep-install: sudo apt-get install -y cmake doxygen graphviz clang libc++-dev libc++abi-dev
           build_with_libcpp: ON
+          special_symlink: ln -s /usr/include/libcxxabi/__cxxabi_config.h /usr/include/c++/v1/__cxxabi_config.h
         # - name: MacOS-Clang
         #   os: macos-10.15
         #   compiler: clang++
@@ -82,7 +83,7 @@ jobs:
       working-directory: ${{github.workspace}}/build
       shell: bash
       # Execute the build.  You can specify a specific target with "--target <NAME>"
-      run: cmake --build . --config $BUILD_TYPE
+      run: ${{ matrix.special_symlink }} ;  cmake --build . --config $BUILD_TYPE
 
     - name: Test
       working-directory: ${{github.workspace}}/build

--- a/.gitignore
+++ b/.gitignore
@@ -32,14 +32,24 @@
 *.app
 
 
+
+#output directories:
+
 /output*
 build/**
 debug/**
 release/**
 mingw/**
-gcc-rel/**
-gcc-debug/**
-relwithdebinfo/**
+
+
+gcc_release/**
+gcc_debug/**
+gcc_relwithdebinfo/**
+clang_release/**
+clang_debug/**
+clang_relwithdebinfo/**
+
+# ide directories:
 .ccls-cache
 .DS_Store
 compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ option(BUILD_WITH_LIBCPP "Build with libc++ instead of libstdc++, if the compile
 if (BUILD_WITH_LIBCPP AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   add_compile_options("-stdlib=libc++")
   add_link_options("-stdlib=libc++")
+  message(STATUS "Will compile with libc++.")
 endif()
 enable_testing()
 add_subdirectory(googletest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,11 +6,12 @@ include(CheckIPOSupported)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+option(BUILD_WITH_LIBCPP "Build with libc++ instead of libstdc++, if the compiler is clang." OFF)
 
 # include the googletest project for tests:
 # here also the standard library has to be set, if compiling with llvms libc++.
 # Our own compile options are set later.
-if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+if (BUILD_WITH_LIBCPP AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   add_compile_options("-stdlib=libc++")
   add_link_options("-stdlib=libc++")
 endif()
@@ -29,6 +30,7 @@ check_ipo_supported(RESULT is_ipo_supported OUTPUT lto_error)
 if(is_ipo_supported)
   set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
   set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_DEBUG OFF)
+  message(STATUS "Interprocedural optimization activated!")
 else()
   message(STATUS "NO INTERPROCESS OPTIMIZATION!")
   message(STATUS "${lto_error}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,14 @@ include(CheckIPOSupported)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+
+# include the googletest project for tests:
+# here also the standard library has to be set, if compiling with llvms libc++.
+# Our own compile options are set later.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  add_compile_options("-stdlib=libc++")
+  add_link_options("-stdlib=libc++")
+endif()
 enable_testing()
 add_subdirectory(googletest)
 
@@ -59,7 +67,6 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     else()
   message(FATAL "Unknown compiler: ${CMAKE_CXX_COMPILER_ID}")
 endif()
-
 
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required (VERSION 3.12...3.18)
 
-project(Grazer CXX)
+project(Grazer C CXX)
 include(CheckIPOSupported)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -35,7 +35,7 @@ set(debug_clang_options "-fcolor-diagnostics;-Wno-error=unused-private-field")
 
 set(debug_gcc_options "-fdiagnostics-color;-Wno-error=strict-overflow")
 
-set(debug_msvc_options "/permissive-;/W4")
+set(debug_msvc_options "/permissive-;/W3")
 
 
 


### PR DESCRIPTION
The project now is listed as a C and CXX project, because the check for inter
process optimization (a.k.a. link time optimization) fails otherwise.

Also the warning level of Visual Studio is reduced to three because the linting
otherwise clutter the output. Maybe there is a way to suppress messages and
only display warnings with Visual Studio. In that case, that should be used
instead.