### PR TITLE
Clearer status message for ipo and stricter debug build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,10 @@ set(debug_clang_options "-fcolor-diagnostics;-Wno-error=unused-private-field")
 
 set(debug_gcc_options "-fdiagnostics-color;-Wno-error=strict-overflow")
 
-set(debug_msvc_options "/permissive-;/W4;/WX")
+# Warning 4127 warns of if statements that are compile time constants.
+# But templated if statements are often compile time constants and Eigen does not have
+# if constexpr in those places. Therefore we suppress this warning.
+set(debug_msvc_options "/permissive-;/W4;/WX;/wd4127")
 
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,9 +31,9 @@ check_ipo_supported(RESULT is_ipo_supported OUTPUT lto_error)
 if(is_ipo_supported)
   set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
   set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_DEBUG OFF)
-  message(STATUS "Interprocedural optimization activated!")
+  message(STATUS "Interprocedural optimization supported!")
 else()
-  message(STATUS "NO INTERPROCESS OPTIMIZATION!")
+  message(STATUS "NO INTERPROCESS OPTIMIZATION AVAILABLE!")
   message(STATUS "${lto_error}")
 endif()
 
@@ -46,7 +46,7 @@ set(debug_clang_options "-fcolor-diagnostics;-Wno-error=unused-private-field")
 
 set(debug_gcc_options "-fdiagnostics-color;-Wno-error=strict-overflow")
 
-set(debug_msvc_options "/permissive-;/W3")
+set(debug_msvc_options "/permissive-;/W4;/WX")
 
 
 

--- a/src/Newtonsolver/Newtonsolver.cpp
+++ b/src/Newtonsolver/Newtonsolver.cpp
@@ -38,10 +38,8 @@ void Newtonsolver_temp<Problemtype>::evaluate_state_derivative_coeffref(Problemt
                                     last_state, new_state);
 }
 
-template <typename Problemtype>
-long int Newtonsolver_temp<Problemtype>::get_number_non_zeros_jacobian() {
-  return jacobian.nonZeros();
-}
+// template <typename Problemtype>
+// auto Newtonsolver_temp<Problemtype>::get_number_non_zeros_jacobian() 
 
 template <typename Problemtype>
 Solutionstruct Newtonsolver_temp<Problemtype>::solve(

--- a/src/Newtonsolver/include/Newtonsolver.hpp
+++ b/src/Newtonsolver/include/Newtonsolver.hpp
@@ -47,8 +47,9 @@ namespace Solver {
                                             Eigen::Ref<Eigen::VectorXd const> const &last_state,
                                             Eigen::Ref<Eigen::VectorXd const> const &new_state);
 
-
-    long int get_number_non_zeros_jacobian();
+    /// \brief Returns the number of structurally non-zero indices of the
+    /// jacobian.
+    auto get_number_non_zeros_jacobian() { return jacobian.nonZeros(); }
 
     /// \brief This method computes a solution to f(new_state) == 0.
     ///
@@ -57,7 +58,6 @@ namespace Solver {
     /// "Deuflhard and Hohmann: Numerical Analysis in Modern Scientific
     /// Computing". Afterwards there should hold f(new_state) == 0 (up to
     /// tolerance).
-
     Solutionstruct solve(Eigen::Ref<Eigen::VectorXd>new_state, Problemtype &problem,
                          bool newjac, double last_time, double new_time,
                          Eigen::Ref<Eigen::VectorXd const> const &last_state);


### PR DESCRIPTION
The ipo message now states, that ipo is supported instead of activated,
because for debug builds it is not activated.

The warning level of msvc is now again W4 and warnings are treated as errors.
Probably we should check on all this clutter in the output but it has no priority.