### PR TITLE
Replaced the id in Idobject with a unique pointer to string

### DIFF
--- a/src/Model/Network/Idobject.cpp
+++ b/src/Model/Network/Idobject.cpp
@@ -3,10 +3,13 @@
 
 namespace Network {
 
-  std::string Idobject::get_id() const { return id; }
+  Idobject::Idobject(std::string const & _id)
+      : idptr(std::make_unique<std::string>(_id)) {}
 
-  void Idobject::display() const { std::cout << "id: " << id << "\n"; }
+  std::string Idobject::get_id() const { return (*idptr); }
 
-  void Idobject::print_id() const { std::cout << "id: " << id << ", "; }
+  void Idobject::display() const { std::cout << "id: " << (*idptr) << "\n"; }
+
+  void Idobject::print_id() const { std::cout << "id: " << (*idptr) << ", "; }
 
 } // namespace Network

--- a/src/Model/Network/include/Idobject.hpp
+++ b/src/Model/Network/include/Idobject.hpp
@@ -1,11 +1,12 @@
 #pragma once
+#include <memory>
 #include <string>
 
 namespace Network {
 
   class Idobject {
   public:
-    Idobject(std::string _id) : id(_id){};
+    Idobject(std::string const &_id);
 
     virtual ~Idobject(){};
 
@@ -19,7 +20,7 @@ namespace Network {
 
   private:
     /// A unique id for the node.
-    std::string id;
+    std::unique_ptr<std::string> idptr;
   };
 
 } // namespace Network


### PR DESCRIPTION
As the id is only used in the beginning and in the end for writing out the results,
it is useful to take the hit of an additional indirection in the use of id, in order
to make all objects smaller, as they only contain an additional pointer instead of
a full string.