### PR TITLE
Checks for develop

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,7 +2,7 @@ name: CMake
 
 on:
   pull_request:
-    branches: [master]
+    branches: [master,develop]
     types: [synchronize, opened, reopened, ready_for_review]
 
 jobs:


### PR DESCRIPTION
Run checks also for pull requests to develop, although we don't require them to succeed.