### PR TITLE
replaced everything with Eigen::Ref

### DIFF
--- a/src/Model/Balancelaw/Isothermaleulerequation.cpp
+++ b/src/Model/Balancelaw/Isothermaleulerequation.cpp
@@ -29,8 +29,8 @@ namespace Model::Balancelaw {
     return coeff_helper_matrix.lu().solve(spline_constraints);
   }
 
-  Eigen::Vector2d
-  Isothermaleulerequation::flux(Eigen::Vector2d const &state, double diameter) {
+  Eigen::Vector2d Isothermaleulerequation::flux(
+      Eigen::Ref<Eigen::Vector2d const> state, double diameter) {
 
     double rho = state[0];
     double q = state[1];
@@ -44,7 +44,7 @@ namespace Model::Balancelaw {
   }
 
   Eigen::Matrix2d Isothermaleulerequation::dflux_dstate(
-      Eigen::Vector2d const &state, double diameter) {
+      Eigen::Ref<Eigen::Vector2d const> state, double diameter) {
 
     double rho = state[0];
     double q = state[1];
@@ -60,7 +60,8 @@ namespace Model::Balancelaw {
   }
 
   Eigen::Vector2d Isothermaleulerequation::source(
-      Eigen::Vector2d const &state, double diameter, double roughness) {
+      Eigen::Ref<Eigen::Vector2d const> state, double diameter,
+      double roughness) {
 
     double rho = state[0];
     double q = state[1];
@@ -81,7 +82,8 @@ namespace Model::Balancelaw {
   }
 
   Eigen::Matrix2d Isothermaleulerequation::dsource_dstate(
-      Eigen::Vector2d const &state, double diameter, double roughness) {
+      Eigen::Ref<Eigen::Vector2d const> state, double diameter,
+      double roughness) {
     double rho = state[0];
     double q = state[1];
 
@@ -114,7 +116,7 @@ namespace Model::Balancelaw {
   }
 
   Eigen::Vector2d
-  Isothermaleulerequation::p_qvol(Eigen::Vector2d const &state) {
+  Isothermaleulerequation::p_qvol(Eigen::Ref<Eigen::Vector2d const> state) {
     double rho = state[0];
     double q = state[1];
 
@@ -126,8 +128,8 @@ namespace Model::Balancelaw {
     return p_qvol;
   }
 
-  Eigen::Matrix2d
-  Isothermaleulerequation::dp_qvol_dstate(Eigen::Vector2d const &state) {
+  Eigen::Matrix2d Isothermaleulerequation::dp_qvol_dstate(
+      Eigen::Ref<Eigen::Vector2d const> state) {
     double rho = state[0];
 
     Eigen::Matrix2d dp_qvol;
@@ -139,7 +141,7 @@ namespace Model::Balancelaw {
   }
 
   Eigen::Vector2d
-  Isothermaleulerequation::state(Eigen::Vector2d const &p_qvol) {
+  Isothermaleulerequation::state(Eigen::Ref<Eigen::Vector2d const> p_qvol) {
 
     double p = p_qvol[0];
     double q = p_qvol[1];
@@ -150,7 +152,7 @@ namespace Model::Balancelaw {
   }
 
   Eigen::Vector2d Isothermaleulerequation::p_qvol_from_p_qvol_bar(
-      Eigen::Vector2d const &p_qvol_bar) {
+      Eigen::Ref<Eigen::Vector2d const> p_qvol_bar) {
     double p_bar = p_qvol_bar[0];
     double q = p_qvol_bar[1];
     Eigen::Vector2d p_qvol;
@@ -172,7 +174,7 @@ namespace Model::Balancelaw {
   }
 
   Eigen::Vector2d Isothermaleulerequation::p_qvol_bar_from_p_qvol(
-      Eigen::Vector2d const &p_qvol) {
+      Eigen::Ref<Eigen::Vector2d const> p_qvol) {
     double p = p_qvol[0];
     double q = p_qvol[1];
     Eigen::Vector2d p_qvol_bar;
@@ -182,7 +184,7 @@ namespace Model::Balancelaw {
   }
 
   Eigen::Matrix2d Isothermaleulerequation::dp_qvol_bar_from_p_qvold_p_qvol(
-      Eigen::Vector2d const &p_qvol) {
+      Eigen::Ref<Eigen::Vector2d const> p_qvol) {
     double p_pascal = p_qvol[0];
     Eigen::Matrix2d dp_qvol;
     dp_qvol(0, 0) = dp_bar_from_p_pascal_dp_pascal(p_pascal);

--- a/src/Model/Balancelaw/include/Isothermaleulerequation.hpp
+++ b/src/Model/Balancelaw/include/Isothermaleulerequation.hpp
@@ -8,30 +8,34 @@ namespace Model::Balancelaw {
   public:
     Isothermaleulerequation(){};
 
-    static Eigen::Vector2d flux(Eigen::Vector2d const &state, double diameter);
-    static Eigen::Matrix2d
-    dflux_dstate(Eigen::Vector2d const &state, double diameter);
-
     static Eigen::Vector2d
-    source(Eigen::Vector2d const &state, double diameter, double roughness);
+    flux(Eigen::Ref<Eigen::Vector2d const> state, double diameter);
+    static Eigen::Matrix2d
+    dflux_dstate(Eigen::Ref<Eigen::Vector2d const> state, double diameter);
+
+    static Eigen::Vector2d source(
+        Eigen::Ref<Eigen::Vector2d const> state, double diameter,
+        double roughness);
     static Eigen::Matrix2d dsource_dstate(
-        Eigen::Vector2d const &state, double diameter, double roughness);
+        Eigen::Ref<Eigen::Vector2d const> state, double diameter,
+        double roughness);
 
-    static Eigen::Vector2d p_qvol(Eigen::Vector2d const &state);
-    static Eigen::Matrix2d dp_qvol_dstate(Eigen::Vector2d const &state);
+    static Eigen::Vector2d p_qvol(Eigen::Ref<Eigen::Vector2d const> state);
+    static Eigen::Matrix2d
+    dp_qvol_dstate(Eigen::Ref<Eigen::Vector2d const> state);
 
-    static Eigen::Vector2d state(Eigen::Vector2d const &p_qvol);
+    static Eigen::Vector2d state(Eigen::Ref<Eigen::Vector2d const> p_qvol);
     static double p_pascal_from_p_bar(double p);
     static Eigen::Vector2d
-    p_qvol_from_p_qvol_bar(Eigen::Vector2d const &p_qvol_bar);
+    p_qvol_from_p_qvol_bar(Eigen::Ref<Eigen::Vector2d const> p_qvol_bar);
 
     static double p_bar_from_p_pascal(double p);
     static double dp_bar_from_p_pascal_dp_pascal(double p);
 
     static Eigen::Vector2d
-    p_qvol_bar_from_p_qvol(Eigen::Vector2d const &p_qvol);
+    p_qvol_bar_from_p_qvol(Eigen::Ref<Eigen::Vector2d const> p_qvol);
     static Eigen::Matrix2d
-    dp_qvol_bar_from_p_qvold_p_qvol(Eigen::Vector2d const &p_qvol);
+    dp_qvol_bar_from_p_qvold_p_qvol(Eigen::Ref<Eigen::Vector2d const> p_qvol);
 
     static double p(double rho);
     static double dp_drho(double rho);
@@ -78,12 +82,5 @@ namespace Model::Balancelaw {
     static Eigen::Matrix4d const set_coeff_helper_matrix();
 
     static const Eigen::Matrix4d coeff_helper_matrix;
-
-    // Eigen::Vector4d coefficients;
-
-    // /// This is a tolerance for the newton iteration:
-    // static constexpr double tolerance = 1e-6;
-    // /// This is an ad-hoc mechanism to prevent too many Newton iterations in
-    // finding the correct friction factor lambda. double last_mu{10.0};
   };
 } // namespace Model::Balancelaw

--- a/src/Model/Networkproblem/Equationcomponent/include/Equationcomponent.hpp
+++ b/src/Model/Networkproblem/Equationcomponent/include/Equationcomponent.hpp
@@ -35,8 +35,8 @@ namespace Model::Networkproblem {
     /// @param new_state value of the state at current time step.
     virtual void evaluate(
         Eigen::Ref<Eigen::VectorXd> rootvalues, double last_time,
-        double new_time, Eigen::Ref<Eigen::VectorXd const> const &last_state,
-        Eigen::Ref<Eigen::VectorXd const> const &new_state) const = 0;
+        double new_time, Eigen::Ref<Eigen::VectorXd const> last_state,
+        Eigen::Ref<Eigen::VectorXd const> new_state) const = 0;
 
     /// \brief derivative of Equationcomponent::evaluate.
     ///
@@ -51,8 +51,8 @@ namespace Model::Networkproblem {
     /// @param new_state value of the state at current time step.
     virtual void evaluate_state_derivative(
         Aux::Matrixhandler *jacobianhandler, double last_time, double new_time,
-        Eigen::Ref<Eigen::VectorXd const> const &,
-        Eigen::Ref<Eigen::VectorXd const> const &new_state) const = 0;
+        Eigen::Ref<Eigen::VectorXd const>,
+        Eigen::Ref<Eigen::VectorXd const> new_state) const = 0;
 
     /// \brief Returns number of state variables needed by this component.
     ///
@@ -97,7 +97,7 @@ namespace Model::Networkproblem {
     /// @param state State of all variables. Only the values in the owned
     /// indices are saved.
     virtual void
-    save_values(double time, Eigen::Ref<Eigen::VectorXd const> const &state)
+    save_values(double time, Eigen::Ref<Eigen::VectorXd const> state)
         = 0;
 
     /// \brief Fills the indices owned by this component with initial values

--- a/src/Model/Networkproblem/Gas/Controlvalve.cpp
+++ b/src/Model/Networkproblem/Gas/Controlvalve.cpp
@@ -23,8 +23,8 @@ namespace Model::Networkproblem::Gas {
 
   void Controlvalve::evaluate(
       Eigen::Ref<Eigen::VectorXd> rootvalues, double, double new_time,
-      Eigen::Ref<Eigen::VectorXd const> const &,
-      Eigen::Ref<Eigen::VectorXd const> const &new_state) const {
+      Eigen::Ref<Eigen::VectorXd const>,
+      Eigen::Ref<Eigen::VectorXd const> new_state) const {
 
     Eigen::Vector2d pressure_control(control_values(new_time)[0], 0.0);
     rootvalues.segment<2>(get_equation_start_index())
@@ -34,8 +34,8 @@ namespace Model::Networkproblem::Gas {
 
   void Controlvalve::evaluate_state_derivative(
       Aux::Matrixhandler *jacobianhandler, double, double,
-      Eigen::Ref<Eigen::VectorXd const> const &,
-      Eigen::Ref<Eigen::VectorXd const> const &) const {
+      Eigen::Ref<Eigen::VectorXd const>,
+      Eigen::Ref<Eigen::VectorXd const>) const {
     auto start_p_index = get_boundary_state_index(1);
     auto start_q_index = start_p_index + 1;
     auto end_p_index = get_boundary_state_index(-1);

--- a/src/Model/Networkproblem/Gas/Flowboundarynode.cpp
+++ b/src/Model/Networkproblem/Gas/Flowboundarynode.cpp
@@ -18,8 +18,8 @@ namespace Model::Networkproblem::Gas {
 
   void Flowboundarynode::evaluate(
       Eigen::Ref<Eigen::VectorXd> rootvalues, double, double new_time,
-      Eigen::Ref<Eigen::VectorXd const> const &,
-      Eigen::Ref<Eigen::VectorXd const> const &new_state) const {
+      Eigen::Ref<Eigen::VectorXd const>,
+      Eigen::Ref<Eigen::VectorXd const> new_state) const {
 
     if (directed_attached_gas_edges.empty()) {
       return;
@@ -31,8 +31,8 @@ namespace Model::Networkproblem::Gas {
 
   void Flowboundarynode::evaluate_state_derivative(
       Aux::Matrixhandler *jacobianhandler, double, double,
-      Eigen::Ref<Eigen::VectorXd const> const &,
-      Eigen::Ref<Eigen::VectorXd const> const &new_state) const {
+      Eigen::Ref<Eigen::VectorXd const>,
+      Eigen::Ref<Eigen::VectorXd const> new_state) const {
     if (directed_attached_gas_edges.empty()) {
       return;
     }

--- a/src/Model/Networkproblem/Gas/Gasedge.cpp
+++ b/src/Model/Networkproblem/Gas/Gasedge.cpp
@@ -81,20 +81,20 @@ namespace Model::Networkproblem::Gas {
            ", which is not +1 or -1! Edge id is: ", this_idobject->get_id()});
     }
   }
-  Eigen::Vector2d Gasedge::get_starting_state(
-      Eigen::Ref<Eigen::VectorXd const> const &state) const {
+  Eigen::Vector2d
+  Gasedge::get_starting_state(Eigen::Ref<Eigen::VectorXd const> state) const {
     Eigen::Vector2d starting_state
         = state.segment<2>(get_starting_state_index());
     return starting_state;
   }
 
-  Eigen::Vector2d Gasedge::get_ending_state(
-      Eigen::Ref<Eigen::VectorXd const> const &state) const {
+  Eigen::Vector2d
+  Gasedge::get_ending_state(Eigen::Ref<Eigen::VectorXd const> state) const {
     Eigen::Vector2d ending_state = state.segment<2>(get_ending_state_index());
     return ending_state;
   }
   Eigen::Vector2d Gasedge::get_boundary_state(
-      int direction, Eigen::Ref<Eigen::VectorXd const> const &state) const {
+      int direction, Eigen::Ref<Eigen::VectorXd const> state) const {
     if (direction == 1) {
       return get_starting_state(state);
     } else if (direction == -1) {

--- a/src/Model/Networkproblem/Gas/Gasnode.cpp
+++ b/src/Model/Networkproblem/Gas/Gasnode.cpp
@@ -10,8 +10,7 @@ namespace Model::Networkproblem::Gas {
 
   void Gasnode::evaluate_flow_node_balance(
       Eigen::Ref<Eigen::VectorXd> rootvalues,
-      Eigen::Ref<Eigen::VectorXd const> const &state,
-      double prescribed_qvol) const {
+      Eigen::Ref<Eigen::VectorXd const> state, double prescribed_qvol) const {
 
     if (directed_attached_gas_edges.empty()) {
       return;
@@ -54,7 +53,7 @@ namespace Model::Networkproblem::Gas {
 
   void Gasnode::evaluate_flow_node_derivative(
       Aux::Matrixhandler *jacobianhandler,
-      Eigen::Ref<Eigen::VectorXd const> const &state) const {
+      Eigen::Ref<Eigen::VectorXd const> state) const {
 
     if (directed_attached_gas_edges.empty()) {
       return;

--- a/src/Model/Networkproblem/Gas/Innode.cpp
+++ b/src/Model/Networkproblem/Gas/Innode.cpp
@@ -7,14 +7,14 @@ namespace Model::Networkproblem::Gas {
 
   void Innode::evaluate(
       Eigen::Ref<Eigen::VectorXd> rootvalues, double, double,
-      Eigen::Ref<Eigen::VectorXd const> const &,
-      Eigen::Ref<Eigen::VectorXd const> const &new_state) const {
+      Eigen::Ref<Eigen::VectorXd const>,
+      Eigen::Ref<Eigen::VectorXd const> new_state) const {
     evaluate_flow_node_balance(rootvalues, new_state, 0.0);
   }
   void Innode::evaluate_state_derivative(
       Aux::Matrixhandler *jacobianhandler, double, double,
-      Eigen::Ref<Eigen::VectorXd const> const &,
-      Eigen::Ref<Eigen::VectorXd const> const &new_state) const {
+      Eigen::Ref<Eigen::VectorXd const>,
+      Eigen::Ref<Eigen::VectorXd const> new_state) const {
     evaluate_flow_node_derivative(jacobianhandler, new_state);
   }
 

--- a/src/Model/Networkproblem/Gas/Pipe.cpp
+++ b/src/Model/Networkproblem/Gas/Pipe.cpp
@@ -52,8 +52,8 @@ namespace Model::Networkproblem::Gas {
 
   void Pipe::evaluate(
       Eigen::Ref<Eigen::VectorXd> rootvalues, double last_time, double new_time,
-      Eigen::Ref<Eigen::VectorXd const> const &last_state,
-      Eigen::Ref<Eigen::VectorXd const> const &new_state) const {
+      Eigen::Ref<Eigen::VectorXd const> last_state,
+      Eigen::Ref<Eigen::VectorXd const> new_state) const {
     for (int i = get_equation_start_index(); i != get_equation_after_index();
          i += 2) {
 
@@ -72,8 +72,8 @@ namespace Model::Networkproblem::Gas {
 
   void Pipe::evaluate_state_derivative(
       Aux::Matrixhandler *jacobianhandler, double last_time, double new_time,
-      Eigen::Ref<Eigen::VectorXd const> const &last_state,
-      Eigen::Ref<Eigen::VectorXd const> const &new_state) const {
+      Eigen::Ref<Eigen::VectorXd const> last_state,
+      Eigen::Ref<Eigen::VectorXd const> new_state) const {
     for (int i = get_equation_start_index(); i != get_equation_after_index();
          i += 2) {
       // maybe use Eigen::Ref here to avoid copies.
@@ -150,8 +150,7 @@ namespace Model::Networkproblem::Gas {
     }
   }
 
-  void Pipe::save_values(
-      double time, Eigen::Ref<Eigen::VectorXd const> const &state) {
+  void Pipe::save_values(double time, Eigen::Ref<Eigen::VectorXd const> state) {
     std::map<double, double> pressure_map;
     std::map<double, double> flow_map;
 
@@ -191,7 +190,7 @@ namespace Model::Networkproblem::Gas {
   }
 
   Eigen::Vector2d Pipe::get_boundary_p_qvol_bar(
-      int direction, Eigen::Ref<Eigen::VectorXd const> const &state) const {
+      int direction, Eigen::Ref<Eigen::VectorXd const> state) const {
     Eigen::Vector2d b_state = get_boundary_state(direction, state);
     Eigen::Vector2d p_qvol = bl.p_qvol(b_state);
     return bl.p_qvol_bar_from_p_qvol(p_qvol);
@@ -200,7 +199,7 @@ namespace Model::Networkproblem::Gas {
   void Pipe::dboundary_p_qvol_dstate(
       int direction, Aux::Matrixhandler *jacobianhandler,
       Eigen::RowVector2d function_derivative, int rootvalues_index,
-      Eigen::Ref<Eigen::VectorXd const> const &state) const {
+      Eigen::Ref<Eigen::VectorXd const> state) const {
     Eigen::Vector2d boundary_state = get_boundary_state(direction, state);
 
     Eigen::Vector2d p_qvol = bl.p_qvol(boundary_state);

--- a/src/Model/Networkproblem/Gas/Shortcomponent.cpp
+++ b/src/Model/Networkproblem/Gas/Shortcomponent.cpp
@@ -55,7 +55,7 @@ namespace Model::Networkproblem::Gas {
   }
 
   void Shortcomponent::save_values(
-      double time, Eigen::Ref<Eigen::VectorXd const> const &state) {
+      double time, Eigen::Ref<Eigen::VectorXd const> state) {
     std::map<double, double> pressure_map;
     std::map<double, double> flow_map;
 
@@ -92,14 +92,14 @@ namespace Model::Networkproblem::Gas {
   }
 
   Eigen::Vector2d Shortcomponent::get_boundary_p_qvol_bar(
-      int direction, Eigen::Ref<Eigen::VectorXd const> const &state) const {
+      int direction, Eigen::Ref<Eigen::VectorXd const> state) const {
     return get_boundary_state(direction, state);
   }
 
   void Shortcomponent::dboundary_p_qvol_dstate(
       int direction, Aux::Matrixhandler *jacobianhandler,
       Eigen::RowVector2d function_derivative, int rootvalues_index,
-      Eigen::Ref<Eigen::VectorXd const> const &) const {
+      Eigen::Ref<Eigen::VectorXd const>) const {
     int p_index = get_boundary_state_index(direction);
     int q_index = p_index + 1;
 

--- a/src/Model/Networkproblem/Gas/Shortpipe.cpp
+++ b/src/Model/Networkproblem/Gas/Shortpipe.cpp
@@ -10,16 +10,16 @@ namespace Model::Networkproblem::Gas {
 
   void Shortpipe::evaluate(
       Eigen::Ref<Eigen::VectorXd> rootvalues, double, double,
-      Eigen::Ref<Eigen::VectorXd const> const &,
-      Eigen::Ref<Eigen::VectorXd const> const &new_state) const {
+      Eigen::Ref<Eigen::VectorXd const>,
+      Eigen::Ref<Eigen::VectorXd const> new_state) const {
     rootvalues.segment<2>(get_equation_start_index())
         = get_boundary_state(1, new_state) - get_boundary_state(-1, new_state);
   }
 
   void Shortpipe::evaluate_state_derivative(
       Aux::Matrixhandler *jacobianhandler, double, double,
-      Eigen::Ref<Eigen::VectorXd const> const &,
-      Eigen::Ref<Eigen::VectorXd const> const &) const {
+      Eigen::Ref<Eigen::VectorXd const>,
+      Eigen::Ref<Eigen::VectorXd const>) const {
 
     auto start_p_index = get_boundary_state_index(1);
     auto start_q_index = start_p_index + 1;

--- a/src/Model/Networkproblem/Gas/include/Controlvalve.hpp
+++ b/src/Model/Networkproblem/Gas/include/Controlvalve.hpp
@@ -18,12 +18,12 @@ namespace Model::Networkproblem::Gas {
 
     void evaluate(
         Eigen::Ref<Eigen::VectorXd> rootvalues, double last_time,
-        double new_time, Eigen::Ref<Eigen::VectorXd const> const &last_state,
-        Eigen::Ref<Eigen::VectorXd const> const &new_state) const override;
+        double new_time, Eigen::Ref<Eigen::VectorXd const> last_state,
+        Eigen::Ref<Eigen::VectorXd const> new_state) const override;
     void evaluate_state_derivative(
         Aux::Matrixhandler *jacobianhandler, double last_time, double new_time,
-        Eigen::Ref<Eigen::VectorXd const> const &,
-        Eigen::Ref<Eigen::VectorXd const> const &new_state) const override;
+        Eigen::Ref<Eigen::VectorXd const>,
+        Eigen::Ref<Eigen::VectorXd const> new_state) const override;
 
     void set_initial_values(
         Eigen::Ref<Eigen::VectorXd> new_state,

--- a/src/Model/Networkproblem/Gas/include/Flowboundarynode.hpp
+++ b/src/Model/Networkproblem/Gas/include/Flowboundarynode.hpp
@@ -19,14 +19,12 @@ namespace Model::Networkproblem::Gas {
 
     void evaluate(
         Eigen::Ref<Eigen::VectorXd> rootvalues, double last_time,
-        double new_time, Eigen::Ref<Eigen::VectorXd const> const &last_state,
-        Eigen::Ref<Eigen::VectorXd const> const &new_state)
-        const override final;
+        double new_time, Eigen::Ref<Eigen::VectorXd const> last_state,
+        Eigen::Ref<Eigen::VectorXd const> new_state) const override final;
     void evaluate_state_derivative(
         Aux::Matrixhandler *jacobianhandler, double last_time, double new_time,
-        Eigen::Ref<Eigen::VectorXd const> const &,
-        Eigen::Ref<Eigen::VectorXd const> const &new_state)
-        const override final;
+        Eigen::Ref<Eigen::VectorXd const>,
+        Eigen::Ref<Eigen::VectorXd const> new_state) const override final;
 
   private:
     Boundaryvalue<1> const boundaryvalue;

--- a/src/Model/Networkproblem/Gas/include/Gasedge.hpp
+++ b/src/Model/Networkproblem/Gas/include/Gasedge.hpp
@@ -17,13 +17,12 @@ namespace Model::Networkproblem::Gas {
 
     /// Returns the boundary
     Eigen::Vector2d get_boundary_state(
-        int direction, Eigen::Ref<Eigen::VectorXd const> const &state) const;
+        int direction, Eigen::Ref<Eigen::VectorXd const> state) const;
 
     /// returns the boundary state expressed in pressure and volumetric flow.
     /// It is the responsibility of the edge to decide what that means.
     virtual Eigen::Vector2d get_boundary_p_qvol_bar(
-        int direction,
-        Eigen::Ref<Eigen::VectorXd const> const &state) const = 0;
+        int direction, Eigen::Ref<Eigen::VectorXd const> state) const = 0;
 
     /// @brief Set the derivatives with respect to the boundary states.
     ///
@@ -36,13 +35,13 @@ namespace Model::Networkproblem::Gas {
     virtual void dboundary_p_qvol_dstate(
         int direction, Aux::Matrixhandler *jacobianhandler,
         Eigen::RowVector2d function_derivative, int rootvalues_index,
-        Eigen::Ref<Eigen::VectorXd const> const &state) const = 0;
+        Eigen::Ref<Eigen::VectorXd const> state) const = 0;
 
   private:
     Eigen::Vector2d
-    get_starting_state(Eigen::Ref<Eigen::VectorXd const> const &state) const;
+    get_starting_state(Eigen::Ref<Eigen::VectorXd const> state) const;
     Eigen::Vector2d
-    get_ending_state(Eigen::Ref<Eigen::VectorXd const> const &state) const;
+    get_ending_state(Eigen::Ref<Eigen::VectorXd const> state) const;
 
     int give_away_start_index() const;
     int give_away_end_index() const;

--- a/src/Model/Networkproblem/Gas/include/Gasnode.hpp
+++ b/src/Model/Networkproblem/Gas/include/Gasnode.hpp
@@ -19,7 +19,7 @@ namespace Model::Networkproblem::Gas {
 
     void print_to_files(std::filesystem::path const &) final{};
 
-    void save_values(double, Eigen::Ref<Eigen::VectorXd const> const &) final{};
+    void save_values(double, Eigen::Ref<Eigen::VectorXd const>) final{};
 
     void set_initial_values(
         Eigen::Ref<Eigen::VectorXd>, nlohmann::ordered_json) final{};
@@ -27,12 +27,11 @@ namespace Model::Networkproblem::Gas {
   protected:
     void evaluate_flow_node_balance(
         Eigen::Ref<Eigen::VectorXd> rootvalues,
-        Eigen::Ref<Eigen::VectorXd const> const &state,
-        double prescribed_flow) const;
+        Eigen::Ref<Eigen::VectorXd const> state, double prescribed_flow) const;
 
     void evaluate_flow_node_derivative(
         Aux::Matrixhandler *jacobianhandler,
-        Eigen::Ref<Eigen::VectorXd const> const &state) const;
+        Eigen::Ref<Eigen::VectorXd const> state) const;
 
     std::vector<std::pair<int, Gasedge *>> directed_attached_gas_edges;
 

--- a/src/Model/Networkproblem/Gas/include/Innode.hpp
+++ b/src/Model/Networkproblem/Gas/include/Innode.hpp
@@ -16,12 +16,12 @@ namespace Model::Networkproblem::Gas {
 
     void evaluate(
         Eigen::Ref<Eigen::VectorXd> rootvalues, double last_time,
-        double new_time, Eigen::Ref<Eigen::VectorXd const> const &last_state,
-        Eigen::Ref<Eigen::VectorXd const> const &new_state) const override;
+        double new_time, Eigen::Ref<Eigen::VectorXd const> last_state,
+        Eigen::Ref<Eigen::VectorXd const> new_state) const override;
     void evaluate_state_derivative(
         Aux::Matrixhandler *jacobianhandler, double last_time, double new_time,
-        Eigen::Ref<Eigen::VectorXd const> const &,
-        Eigen::Ref<Eigen::VectorXd const> const &new_state) const override;
+        Eigen::Ref<Eigen::VectorXd const>,
+        Eigen::Ref<Eigen::VectorXd const> new_state) const override;
   };
 
 } // namespace Model::Networkproblem::Gas

--- a/src/Model/Networkproblem/Gas/include/Pipe.hpp
+++ b/src/Model/Networkproblem/Gas/include/Pipe.hpp
@@ -18,32 +18,31 @@ namespace Model::Networkproblem::Gas {
 
     void evaluate(
         Eigen::Ref<Eigen::VectorXd> rootvalues, double last_time,
-        double new_time, Eigen::Ref<Eigen::VectorXd const> const &last_state,
-        Eigen::Ref<Eigen::VectorXd const> const &new_state) const override;
+        double new_time, Eigen::Ref<Eigen::VectorXd const> last_state,
+        Eigen::Ref<Eigen::VectorXd const> new_state) const override;
     void evaluate_state_derivative(
         Aux::Matrixhandler *jacobianhandler, double last_time, double new_time,
-        Eigen::Ref<Eigen::VectorXd const> const &,
-        Eigen::Ref<Eigen::VectorXd const> const &new_state) const override;
+        Eigen::Ref<Eigen::VectorXd const>,
+        Eigen::Ref<Eigen::VectorXd const> new_state) const override;
 
     int get_number_of_states() const override;
 
     void print_to_files(std::filesystem::path const &output_directory) override;
 
-    void save_values(
-        double time, Eigen::Ref<Eigen::VectorXd const> const &state) override;
+    void
+    save_values(double time, Eigen::Ref<Eigen::VectorXd const> state) override;
 
     void set_initial_values(
         Eigen::Ref<Eigen::VectorXd> new_state,
         nlohmann::ordered_json initial_json) override;
 
     Eigen::Vector2d get_boundary_p_qvol_bar(
-        int direction,
-        Eigen::Ref<Eigen::VectorXd const> const &state) const override;
+        int direction, Eigen::Ref<Eigen::VectorXd const> state) const override;
 
     void dboundary_p_qvol_dstate(
         int direction, Aux::Matrixhandler *jacobianhandler,
         Eigen::RowVector2d function_derivative, int rootvalues_index,
-        Eigen::Ref<Eigen::VectorXd const> const &state) const override;
+        Eigen::Ref<Eigen::VectorXd const> state) const override;
 
   private:
     double get_length();

--- a/src/Model/Networkproblem/Gas/include/Shortcomponent.hpp
+++ b/src/Model/Networkproblem/Gas/include/Shortcomponent.hpp
@@ -14,8 +14,8 @@ namespace Model::Networkproblem::Gas {
     void print_helper(
         std::filesystem::path const &output_directory, std::string const &type);
 
-    void save_values(
-        double time, Eigen::Ref<Eigen::VectorXd const> const &state) final;
+    void
+    save_values(double time, Eigen::Ref<Eigen::VectorXd const> state) final;
 
     void initial_values_helper(
         Eigen::Ref<Eigen::VectorXd> new_state,
@@ -25,8 +25,7 @@ namespace Model::Networkproblem::Gas {
     /// variables, so that this function simply returns the corresponding
     /// boundary state.
     Eigen::Vector2d get_boundary_p_qvol_bar(
-        int direction,
-        Eigen::Ref<Eigen::VectorXd const> const &state) const final;
+        int direction, Eigen::Ref<Eigen::VectorXd const> state) const final;
 
     /// Because Shortcomponents use pressure and volumetric flow as their state
     /// variables, this function just hands `function_derivative` to
@@ -34,7 +33,7 @@ namespace Model::Networkproblem::Gas {
     void dboundary_p_qvol_dstate(
         int direction, Aux::Matrixhandler *jacobianhandler,
         Eigen::RowVector2d function_derivative, int rootvalues_index,
-        Eigen::Ref<Eigen::VectorXd const> const &state) const final;
+        Eigen::Ref<Eigen::VectorXd const> state) const final;
 
   private:
     /// \brief number of state variables, this component needs.

--- a/src/Model/Networkproblem/Gas/include/Shortpipe.hpp
+++ b/src/Model/Networkproblem/Gas/include/Shortpipe.hpp
@@ -12,13 +12,13 @@ namespace Model::Networkproblem::Gas {
 
     void evaluate(
         Eigen::Ref<Eigen::VectorXd> rootvalues, double last_time,
-        double new_time, Eigen::Ref<Eigen::VectorXd const> const &last_state,
-        Eigen::Ref<Eigen::VectorXd const> const &new_state) const final;
+        double new_time, Eigen::Ref<Eigen::VectorXd const> last_state,
+        Eigen::Ref<Eigen::VectorXd const> new_state) const final;
 
     void evaluate_state_derivative(
         Aux::Matrixhandler *jacobianhandler, double last_time, double new_time,
-        Eigen::Ref<Eigen::VectorXd const> const &,
-        Eigen::Ref<Eigen::VectorXd const> const &new_state) const final;
+        Eigen::Ref<Eigen::VectorXd const>,
+        Eigen::Ref<Eigen::VectorXd const> new_state) const final;
 
     void set_initial_values(
         Eigen::Ref<Eigen::VectorXd> new_state,

--- a/src/Model/Networkproblem/Gaspowerconnection/Gaspowerconnection.cpp
+++ b/src/Model/Networkproblem/Gaspowerconnection/Gaspowerconnection.cpp
@@ -33,8 +33,8 @@ namespace Model::Networkproblem::Gaspowerconnection {
 
   void Gaspowerconnection::evaluate(
       Eigen::Ref<Eigen::VectorXd> rootvalues, double, double,
-      Eigen::Ref<Eigen::VectorXd const> const &,
-      Eigen::Ref<Eigen::VectorXd const> const &new_state) const {
+      Eigen::Ref<Eigen::VectorXd const>,
+      Eigen::Ref<Eigen::VectorXd const> new_state) const {
     int q_index = get_start_state_index() + 1;
     rootvalues[q_index]
         = powerendnode->P(new_state) - generated_power(new_state[q_index]);
@@ -42,8 +42,8 @@ namespace Model::Networkproblem::Gaspowerconnection {
 
   void Gaspowerconnection::evaluate_state_derivative(
       Aux::Matrixhandler *jacobianhandler, double, double,
-      Eigen::Ref<Eigen::VectorXd const> const &,
-      Eigen::Ref<Eigen::VectorXd const> const &new_state) const {
+      Eigen::Ref<Eigen::VectorXd const>,
+      Eigen::Ref<Eigen::VectorXd const> new_state) const {
     int q_index = get_start_state_index() + 1;
     double q = new_state[q_index];
     jacobianhandler->set_coefficient(q_index, q_index, -dgenerated_power_dq(q));
@@ -109,7 +109,7 @@ namespace Model::Networkproblem::Gaspowerconnection {
   }
 
   void Gaspowerconnection::save_values(
-      double time, Eigen::Ref<Eigen::VectorXd const> const &state) {
+      double time, Eigen::Ref<Eigen::VectorXd const> state) {
     std::map<double, double> pressure_map;
     std::map<double, double> flow_map;
 
@@ -147,14 +147,14 @@ namespace Model::Networkproblem::Gaspowerconnection {
   }
 
   Eigen::Vector2d Gaspowerconnection::get_boundary_p_qvol_bar(
-      int direction, Eigen::Ref<Eigen::VectorXd const> const &state) const {
+      int direction, Eigen::Ref<Eigen::VectorXd const> state) const {
     return get_boundary_state(direction, state);
   }
 
   void Gaspowerconnection::dboundary_p_qvol_dstate(
       int direction, Aux::Matrixhandler *jacobianhandler,
       Eigen::RowVector2d function_derivative, int rootvalues_index,
-      Eigen::Ref<Eigen::VectorXd const> const &) const {
+      Eigen::Ref<Eigen::VectorXd const>) const {
     int p_index = get_boundary_state_index(direction);
     int q_index = p_index + 1;
     jacobianhandler->set_coefficient(

--- a/src/Model/Networkproblem/Gaspowerconnection/include/Gaspowerconnection.hpp
+++ b/src/Model/Networkproblem/Gaspowerconnection/include/Gaspowerconnection.hpp
@@ -19,12 +19,12 @@ namespace Model::Networkproblem::Gaspowerconnection {
 
     void evaluate(
         Eigen::Ref<Eigen::VectorXd> rootvalues, double last_time,
-        double new_time, Eigen::Ref<Eigen::VectorXd const> const &last_state,
-        Eigen::Ref<Eigen::VectorXd const> const &new_state) const override;
+        double new_time, Eigen::Ref<Eigen::VectorXd const> last_state,
+        Eigen::Ref<Eigen::VectorXd const> new_state) const override;
     void evaluate_state_derivative(
         Aux::Matrixhandler *jacobianhandler, double last_time, double new_time,
-        Eigen::Ref<Eigen::VectorXd const> const &,
-        Eigen::Ref<Eigen::VectorXd const> const &new_state) const override;
+        Eigen::Ref<Eigen::VectorXd const>,
+        Eigen::Ref<Eigen::VectorXd const> new_state) const override;
 
     void setup() override;
 
@@ -32,21 +32,20 @@ namespace Model::Networkproblem::Gaspowerconnection {
 
     void print_to_files(std::filesystem::path const &output_directory) override;
 
-    void save_values(
-        double time, Eigen::Ref<Eigen::VectorXd const> const &state) override;
+    void
+    save_values(double time, Eigen::Ref<Eigen::VectorXd const> state) override;
 
     void set_initial_values(
         Eigen::Ref<Eigen::VectorXd> new_state,
         nlohmann::ordered_json initial_json) override;
 
     Eigen::Vector2d get_boundary_p_qvol_bar(
-        int direction,
-        Eigen::Ref<Eigen::VectorXd const> const &state) const override;
+        int direction, Eigen::Ref<Eigen::VectorXd const> state) const override;
 
     void dboundary_p_qvol_dstate(
         int direction, Aux::Matrixhandler *jacobianhandler,
         Eigen::RowVector2d function_derivative, int rootvalues_index,
-        Eigen::Ref<Eigen::VectorXd const> const &state) const override;
+        Eigen::Ref<Eigen::VectorXd const> state) const override;
 
     double smoothing_polynomial(double q) const;
     double dsmoothing_polynomial_dq(double q) const;

--- a/src/Model/Networkproblem/Networkproblem.cpp
+++ b/src/Model/Networkproblem/Networkproblem.cpp
@@ -39,8 +39,8 @@ namespace Model::Networkproblem {
 
   void Networkproblem::evaluate(
       Eigen::Ref<Eigen::VectorXd> rootvalues, double last_time, double new_time,
-      Eigen::Ref<Eigen::VectorXd const> const &last_state,
-      Eigen::Ref<Eigen::VectorXd const> const &new_state) const {
+      Eigen::Ref<Eigen::VectorXd const> last_state,
+      Eigen::Ref<Eigen::VectorXd const> new_state) const {
 
     // // This should evaluate in parallel, test on bigger problems later on:
     // std::for_each(std::execution::par_unseq, equationcomponents.begin(),
@@ -59,8 +59,8 @@ namespace Model::Networkproblem {
 
   void Networkproblem::evaluate_state_derivative(
       ::Aux::Matrixhandler *jacobianhandler, double last_time, double new_time,
-      Eigen::Ref<Eigen::VectorXd const> const &last_state,
-      Eigen::Ref<Eigen::VectorXd const> const &new_state) const {
+      Eigen::Ref<Eigen::VectorXd const> last_state,
+      Eigen::Ref<Eigen::VectorXd const> new_state) const {
 
     // // This should evaluate in parallel, test on bigger problems later on:
     // std::for_each(std::execution::par_unseq, equationcomponents.begin(),

--- a/src/Model/Networkproblem/Power/PQnode.cpp
+++ b/src/Model/Networkproblem/Power/PQnode.cpp
@@ -12,8 +12,8 @@ namespace Model::Networkproblem::Power {
 
   void PQnode::evaluate(
       Eigen::Ref<Eigen::VectorXd> rootvalues, double, double new_time,
-      Eigen::Ref<Eigen::VectorXd const> const &,
-      Eigen::Ref<Eigen::VectorXd const> const &new_state) const {
+      Eigen::Ref<Eigen::VectorXd const>,
+      Eigen::Ref<Eigen::VectorXd const> new_state) const {
     int V_index = get_start_state_index();
     int phi_index = V_index + 1;
     rootvalues[V_index] = P(new_state) - boundaryvalue(new_time)[0];
@@ -26,16 +26,16 @@ namespace Model::Networkproblem::Power {
       ,
       double // new_time
       ,
-      Eigen::Ref<Eigen::VectorXd const> const &,
-      Eigen::Ref<Eigen::VectorXd const> const &new_state) const {
+      Eigen::Ref<Eigen::VectorXd const>,
+      Eigen::Ref<Eigen::VectorXd const> new_state) const {
     int first_equation_index = get_start_state_index();
     int second_equation_index = first_equation_index + 1;
     evaluate_P_derivative(first_equation_index, jacobianhandler, new_state);
     evaluate_Q_derivative(second_equation_index, jacobianhandler, new_state);
   }
 
-  void PQnode::save_values(
-      double time, Eigen::Ref<Eigen::VectorXd const> const &state) {
+  void
+  PQnode::save_values(double time, Eigen::Ref<Eigen::VectorXd const> state) {
     auto P_val = boundaryvalue(time)[0];
     auto Q_val = boundaryvalue(time)[1];
     save_power_values(time, state, P_val, Q_val);

--- a/src/Model/Networkproblem/Power/PVnode.cpp
+++ b/src/Model/Networkproblem/Power/PVnode.cpp
@@ -9,8 +9,8 @@ namespace Model::Networkproblem::Power {
   bool PVnode::needs_boundary_values() { return true; }
   void PVnode::evaluate(
       Eigen::Ref<Eigen::VectorXd> rootvalues, double, double new_time,
-      Eigen::Ref<Eigen::VectorXd const> const &,
-      Eigen::Ref<Eigen::VectorXd const> const &new_state) const {
+      Eigen::Ref<Eigen::VectorXd const>,
+      Eigen::Ref<Eigen::VectorXd const> new_state) const {
     int V_index = get_start_state_index();
     int phi_index = V_index + 1;
     rootvalues[V_index] = P(new_state) - boundaryvalue(new_time)[0];
@@ -24,16 +24,16 @@ namespace Model::Networkproblem::Power {
       ,
       double // new_time
       ,
-      Eigen::Ref<Eigen::VectorXd const> const &,
-      Eigen::Ref<Eigen::VectorXd const> const &new_state) const {
+      Eigen::Ref<Eigen::VectorXd const>,
+      Eigen::Ref<Eigen::VectorXd const> new_state) const {
     int V_index = get_start_state_index();
     int phi_index = V_index + 1;
     evaluate_P_derivative(V_index, jacobianhandler, new_state);
     jacobianhandler->set_coefficient(phi_index, V_index, 1.0);
   }
 
-  void PVnode::save_values(
-      double time, Eigen::Ref<Eigen::VectorXd const> const &state) {
+  void
+  PVnode::save_values(double time, Eigen::Ref<Eigen::VectorXd const> state) {
     auto P_val = boundaryvalue(time)[0];
     auto Q_val = Q(state);
     save_power_values(time, state, P_val, Q_val);

--- a/src/Model/Networkproblem/Power/Powernode.cpp
+++ b/src/Model/Networkproblem/Power/Powernode.cpp
@@ -108,7 +108,7 @@ namespace Model::Networkproblem::Power {
   }
 
   void Powernode::save_power_values(
-      double time, Eigen::Ref<Eigen::VectorXd const> const &state, double P_val,
+      double time, Eigen::Ref<Eigen::VectorXd const> state, double P_val,
       double Q_val) {
 
     std::map<double, double> Pmap;
@@ -124,8 +124,7 @@ namespace Model::Networkproblem::Power {
     Equationcomponent::push_to_values(time, value_vector);
   }
 
-  double
-  Powernode::P(Eigen::Ref<Eigen::VectorXd const> const &new_state) const {
+  double Powernode::P(Eigen::Ref<Eigen::VectorXd const> new_state) const {
     int V_index = get_start_state_index();
     int phi_index = V_index + 1;
     double G_i = get_G();
@@ -149,8 +148,7 @@ namespace Model::Networkproblem::Power {
     return P;
   }
 
-  double
-  Powernode::Q(Eigen::Ref<Eigen::VectorXd const> const &new_state) const {
+  double Powernode::Q(Eigen::Ref<Eigen::VectorXd const> new_state) const {
 
     int V_index = get_start_state_index();
     int phi_index = V_index + 1;
@@ -177,7 +175,7 @@ namespace Model::Networkproblem::Power {
 
   void Powernode::evaluate_P_derivative(
       int equationindex, Aux::Matrixhandler *jacobianhandler,
-      Eigen::Ref<Eigen::VectorXd const> const &new_state) const {
+      Eigen::Ref<Eigen::VectorXd const> new_state) const {
     int V_index = get_start_state_index();
     int phi_index = V_index + 1;
     double G_i = get_G();
@@ -215,7 +213,7 @@ namespace Model::Networkproblem::Power {
 
   void Powernode::evaluate_Q_derivative(
       int equationindex, Aux::Matrixhandler *jacobianhandler,
-      Eigen::Ref<Eigen::VectorXd const> const &new_state) const {
+      Eigen::Ref<Eigen::VectorXd const> new_state) const {
     int V_index = get_start_state_index();
     int phi_index = V_index + 1;
     double B_i = get_B();

--- a/src/Model/Networkproblem/Power/Vphinode.cpp
+++ b/src/Model/Networkproblem/Power/Vphinode.cpp
@@ -11,9 +11,9 @@ namespace Model::Networkproblem::Power {
       Eigen::Ref<Eigen::VectorXd> rootvalues, double // last_time
       ,
       double new_time,
-      Eigen::Ref<Eigen::VectorXd const> const & // last_state
+      Eigen::Ref<Eigen::VectorXd const> // last_state
       ,
-      Eigen::Ref<Eigen::VectorXd const> const &new_state) const {
+      Eigen::Ref<Eigen::VectorXd const> new_state) const {
     int V_index = get_start_state_index();
     int phi_index = V_index + 1;
     rootvalues[V_index] = new_state[V_index] - boundaryvalue(new_time)[0];
@@ -27,8 +27,8 @@ namespace Model::Networkproblem::Power {
       ,
       double // new_time
       ,
-      Eigen::Ref<Eigen::VectorXd const> const &,
-      Eigen::Ref<Eigen::VectorXd const> const & // new_state
+      Eigen::Ref<Eigen::VectorXd const>,
+      Eigen::Ref<Eigen::VectorXd const> // new_state
   ) const {
     int V_index = get_start_state_index();
     int phi_index = V_index + 1;
@@ -36,8 +36,8 @@ namespace Model::Networkproblem::Power {
     jacobianhandler->set_coefficient(phi_index, phi_index, 1.0);
   }
 
-  void Vphinode::save_values(
-      double time, Eigen::Ref<Eigen::VectorXd const> const &state) {
+  void
+  Vphinode::save_values(double time, Eigen::Ref<Eigen::VectorXd const> state) {
     auto P_val = P(state);
     auto Q_val = Q(state);
     save_power_values(time, state, P_val, Q_val);

--- a/src/Model/Networkproblem/Power/include/PQnode.hpp
+++ b/src/Model/Networkproblem/Power/include/PQnode.hpp
@@ -15,16 +15,16 @@ namespace Model::Networkproblem::Power {
     /// for P.
     virtual void evaluate(
         Eigen::Ref<Eigen::VectorXd> rootvalues, double last_time,
-        double new_time, Eigen::Ref<Eigen::VectorXd const> const &last_state,
-        Eigen::Ref<Eigen::VectorXd const> const &new_state) const override;
+        double new_time, Eigen::Ref<Eigen::VectorXd const> last_state,
+        Eigen::Ref<Eigen::VectorXd const> new_state) const override;
 
     void evaluate_state_derivative(
         Aux::Matrixhandler *jacobianhandler, double last_time, double new_time,
-        Eigen::Ref<Eigen::VectorXd const> const &,
-        Eigen::Ref<Eigen::VectorXd const> const &new_state) const override;
+        Eigen::Ref<Eigen::VectorXd const>,
+        Eigen::Ref<Eigen::VectorXd const> new_state) const override;
 
-    void save_values(
-        double time, Eigen::Ref<Eigen::VectorXd const> const &state) override;
+    void
+    save_values(double time, Eigen::Ref<Eigen::VectorXd const> state) override;
   };
 
 } // namespace Model::Networkproblem::Power

--- a/src/Model/Networkproblem/Power/include/PVnode.hpp
+++ b/src/Model/Networkproblem/Power/include/PVnode.hpp
@@ -15,16 +15,16 @@ namespace Model::Networkproblem::Power {
     /// for P.
     void evaluate(
         Eigen::Ref<Eigen::VectorXd> rootvalues, double last_time,
-        double new_time, Eigen::Ref<Eigen::VectorXd const> const &last_state,
-        Eigen::Ref<Eigen::VectorXd const> const &new_state) const override;
+        double new_time, Eigen::Ref<Eigen::VectorXd const> last_state,
+        Eigen::Ref<Eigen::VectorXd const> new_state) const override;
 
     void evaluate_state_derivative(
         Aux::Matrixhandler *jacobianhandler, double last_time, double new_time,
-        Eigen::Ref<Eigen::VectorXd const> const &,
-        Eigen::Ref<Eigen::VectorXd const> const &new_state) const override;
+        Eigen::Ref<Eigen::VectorXd const>,
+        Eigen::Ref<Eigen::VectorXd const> new_state) const override;
 
-    void save_values(
-        double time, Eigen::Ref<Eigen::VectorXd const> const &state) override;
+    void
+    save_values(double time, Eigen::Ref<Eigen::VectorXd const> state) override;
   };
 
 } // namespace Model::Networkproblem::Power

--- a/src/Model/Networkproblem/Power/include/Powernode.hpp
+++ b/src/Model/Networkproblem/Power/include/Powernode.hpp
@@ -29,14 +29,14 @@ namespace Model::Networkproblem::Power {
         Eigen::Ref<Eigen::VectorXd> new_state,
         nlohmann::ordered_json initial_json) final;
 
-    double P(Eigen::Ref<Eigen::VectorXd const> const &new_state) const;
-    double Q(Eigen::Ref<Eigen::VectorXd const> const &new_state) const;
+    double P(Eigen::Ref<Eigen::VectorXd const> new_state) const;
+    double Q(Eigen::Ref<Eigen::VectorXd const> new_state) const;
     void evaluate_P_derivative(
         int equationindex, Aux::Matrixhandler *jacobianhandler,
-        Eigen::Ref<Eigen::VectorXd const> const &new_state) const;
+        Eigen::Ref<Eigen::VectorXd const> new_state) const;
     void evaluate_Q_derivative(
         int equationindex, Aux::Matrixhandler *jacobianhandler,
-        Eigen::Ref<Eigen::VectorXd const> const &new_state) const;
+        Eigen::Ref<Eigen::VectorXd const> new_state) const;
 
   protected:
     /// \brief saves the values of a power node for later printout into files.
@@ -45,8 +45,8 @@ namespace Model::Networkproblem::Power {
     /// this is just a helper function that is called from the respective
     /// Powernode.
     void save_power_values(
-        double time, Eigen::Ref<Eigen::VectorXd const> const &state,
-        double P_val, double Q_val);
+        double time, Eigen::Ref<Eigen::VectorXd const> state, double P_val,
+        double Q_val);
 
     Boundaryvalue<2> const boundaryvalue;
     /// Real part of the admittance of this node

--- a/src/Model/Networkproblem/Power/include/Vphinode.hpp
+++ b/src/Model/Networkproblem/Power/include/Vphinode.hpp
@@ -14,16 +14,16 @@ namespace Model::Networkproblem::Power {
     /// In this node we just set V and phi to their respective boundary values.
     void evaluate(
         Eigen::Ref<Eigen::VectorXd> rootvalues, double last_time,
-        double new_time, Eigen::Ref<Eigen::VectorXd const> const &last_state,
-        Eigen::Ref<Eigen::VectorXd const> const &new_state) const override;
+        double new_time, Eigen::Ref<Eigen::VectorXd const> last_state,
+        Eigen::Ref<Eigen::VectorXd const> new_state) const override;
 
     void evaluate_state_derivative(
         Aux::Matrixhandler *jacobianhandler, double last_time, double new_time,
-        Eigen::Ref<Eigen::VectorXd const> const &,
-        Eigen::Ref<Eigen::VectorXd const> const &new_state) const override;
+        Eigen::Ref<Eigen::VectorXd const>,
+        Eigen::Ref<Eigen::VectorXd const> new_state) const override;
 
-    void save_values(
-        double time, Eigen::Ref<Eigen::VectorXd const> const &state) override;
+    void
+    save_values(double time, Eigen::Ref<Eigen::VectorXd const> state) override;
   };
 
 } // namespace Model::Networkproblem::Power

--- a/src/Model/Networkproblem/include/Networkproblem.hpp
+++ b/src/Model/Networkproblem/include/Networkproblem.hpp
@@ -27,12 +27,12 @@ namespace Model::Networkproblem {
 
     void evaluate(
         Eigen::Ref<Eigen::VectorXd> rootvalues, double last_time,
-        double new_time, Eigen::Ref<Eigen::VectorXd const> const &last_state,
-        Eigen::Ref<Eigen::VectorXd const> const &new_state) const final;
+        double new_time, Eigen::Ref<Eigen::VectorXd const> last_state,
+        Eigen::Ref<Eigen::VectorXd const> new_state) const final;
     void evaluate_state_derivative(
         Aux::Matrixhandler *jacobian, double last_time, double new_time,
-        Eigen::Ref<Eigen::VectorXd const> const &last_state,
-        Eigen::Ref<Eigen::VectorXd const> const &new_state) const override;
+        Eigen::Ref<Eigen::VectorXd const> last_state,
+        Eigen::Ref<Eigen::VectorXd const> new_state) const override;
 
     void save_values(double time, Eigen::Ref<Eigen::VectorXd> new_state) final;
 

--- a/src/Model/Problemlayer/Problem.cpp
+++ b/src/Model/Problemlayer/Problem.cpp
@@ -42,8 +42,8 @@ namespace Model {
 
   void Problem::evaluate(
       Eigen::Ref<Eigen::VectorXd> rootvalues, double last_time, double new_time,
-      Eigen::Ref<Eigen::VectorXd const> const &last_state,
-      Eigen::Ref<Eigen::VectorXd const> const &new_state) const {
+      Eigen::Ref<Eigen::VectorXd const> last_state,
+      Eigen::Ref<Eigen::VectorXd const> new_state) const {
     for (auto &subproblem : subproblems) {
       subproblem->evaluate(
           rootvalues, last_time, new_time, last_state, new_state);
@@ -52,8 +52,8 @@ namespace Model {
 
   void Problem::evaluate_state_derivative(
       Aux::Matrixhandler *jacobianhandler, double last_time, double new_time,
-      Eigen::Ref<Eigen::VectorXd const> const &last_state,
-      Eigen::Ref<Eigen::VectorXd const> const &new_state) const {
+      Eigen::Ref<Eigen::VectorXd const> last_state,
+      Eigen::Ref<Eigen::VectorXd const> new_state) const {
     for (auto &subproblem : subproblems) {
       subproblem->evaluate_state_derivative(
           jacobianhandler, last_time, new_time, last_state, new_state);

--- a/src/Model/Problemlayer/include/Problem.hpp
+++ b/src/Model/Problemlayer/include/Problem.hpp
@@ -34,13 +34,13 @@ namespace Model {
 
     void evaluate(
         Eigen::Ref<Eigen::VectorXd> rootvalues, double last_time,
-        double new_time, Eigen::Ref<Eigen::VectorXd const> const &last_state,
-        Eigen::Ref<Eigen::VectorXd const> const &new_state) const;
+        double new_time, Eigen::Ref<Eigen::VectorXd const> last_state,
+        Eigen::Ref<Eigen::VectorXd const> new_state) const;
 
     void evaluate_state_derivative(
         Aux::Matrixhandler *jacobianhandler, double last_time, double new_time,
-        Eigen::Ref<Eigen::VectorXd const> const &last_state,
-        Eigen::Ref<Eigen::VectorXd const> const &new_state) const;
+        Eigen::Ref<Eigen::VectorXd const> last_state,
+        Eigen::Ref<Eigen::VectorXd const> new_state) const;
 
     void save_values(double time, Eigen::Ref<Eigen::VectorXd> new_state);
     /// As we have unique pointers, we can only give back a pointer to our

--- a/src/Model/Scheme/Implicitboxscheme.cpp
+++ b/src/Model/Scheme/Implicitboxscheme.cpp
@@ -6,10 +6,10 @@ namespace Model::Scheme {
   /// Computes the implicit box scheme at one point.
   void Implicitboxscheme::evaluate_point(
       Eigen::Ref<Eigen::Vector2d> result, double last_time, double new_time,
-      double Delta_x, Eigen::Ref<Eigen::Vector2d const> const &last_left,
-      Eigen::Ref<Eigen::Vector2d const> const &last_right,
-      Eigen::Ref<Eigen::Vector2d const> const &new_left,
-      Eigen::Ref<Eigen::Vector2d const> const &new_right,
+      double Delta_x, Eigen::Ref<Eigen::Vector2d const> last_left,
+      Eigen::Ref<Eigen::Vector2d const> last_right,
+      Eigen::Ref<Eigen::Vector2d const> new_left,
+      Eigen::Ref<Eigen::Vector2d const> new_right,
       Model::Balancelaw::Isothermaleulerequation const &bl, double diameter,
       double roughness) {
 
@@ -26,10 +26,9 @@ namespace Model::Scheme {
   /// The derivative with respect to \code{.cpp}last_left\endcode
   Eigen::Matrix2d Implicitboxscheme::devaluate_point_dleft(
       double last_time, double new_time, double Delta_x,
-      Eigen::Ref<Eigen::Vector2d const> const &,
-      Eigen::Ref<Eigen::Vector2d const> const &,
-      Eigen::Ref<Eigen::Vector2d const> const &new_left,
-      Eigen::Ref<Eigen::Vector2d const> const &,
+      Eigen::Ref<Eigen::Vector2d const>, Eigen::Ref<Eigen::Vector2d const>,
+      Eigen::Ref<Eigen::Vector2d const> new_left,
+      Eigen::Ref<Eigen::Vector2d const>,
       Model::Balancelaw::Isothermaleulerequation const &bl, double diameter,
       double roughness) {
     double Delta_t = new_time - last_time;
@@ -44,10 +43,9 @@ namespace Model::Scheme {
   /// The derivative with respect to \code{.cpp}last_right\endcode
   Eigen::Matrix2d Implicitboxscheme::devaluate_point_dright(
       double last_time, double new_time, double Delta_x,
-      Eigen::Ref<Eigen::Vector2d const> const &,
-      Eigen::Ref<Eigen::Vector2d const> const &,
-      Eigen::Ref<Eigen::Vector2d const> const &,
-      Eigen::Ref<Eigen::Vector2d const> const &new_right,
+      Eigen::Ref<Eigen::Vector2d const>, Eigen::Ref<Eigen::Vector2d const>,
+      Eigen::Ref<Eigen::Vector2d const>,
+      Eigen::Ref<Eigen::Vector2d const> new_right,
       Model::Balancelaw::Isothermaleulerequation const &bl, double diameter,
       double roughness) {
     double Delta_t = new_time - last_time;

--- a/src/Model/Scheme/include/Implicitboxscheme.hpp
+++ b/src/Model/Scheme/include/Implicitboxscheme.hpp
@@ -14,30 +14,30 @@ namespace Model::Scheme {
     /// Computes the implicit box scheme at one point.
     static void evaluate_point(
         Eigen::Ref<Eigen::Vector2d> result, double last_time, double new_time,
-        double Delta_x, Eigen::Ref<Eigen::Vector2d const> const &last_left,
-        Eigen::Ref<Eigen::Vector2d const> const &last_right,
-        Eigen::Ref<Eigen::Vector2d const> const &new_left,
-        Eigen::Ref<Eigen::Vector2d const> const &new_right,
+        double Delta_x, Eigen::Ref<Eigen::Vector2d const> last_left,
+        Eigen::Ref<Eigen::Vector2d const> last_right,
+        Eigen::Ref<Eigen::Vector2d const> new_left,
+        Eigen::Ref<Eigen::Vector2d const> new_right,
         Model::Balancelaw::Isothermaleulerequation const &bl, double diameter,
         double roughness);
 
     /// The derivative with respect to \code{.cpp}last_left\endcode
     static Eigen::Matrix2d devaluate_point_dleft(
         double last_time, double new_time, double Delta_x,
-        Eigen::Ref<Eigen::Vector2d const> const &last_left,
-        Eigen::Ref<Eigen::Vector2d const> const &last_right,
-        Eigen::Ref<Eigen::Vector2d const> const &new_left,
-        Eigen::Ref<Eigen::Vector2d const> const &new_right,
+        Eigen::Ref<Eigen::Vector2d const> last_left,
+        Eigen::Ref<Eigen::Vector2d const> last_right,
+        Eigen::Ref<Eigen::Vector2d const> new_left,
+        Eigen::Ref<Eigen::Vector2d const> new_right,
         Model::Balancelaw::Isothermaleulerequation const &bl, double diameter,
         double roughness);
 
     /// \brief The derivative with respect to \code{.cpp}last_right\endcode
     static Eigen::Matrix2d devaluate_point_dright(
         double last_time, double new_time, double Delta_x,
-        Eigen::Ref<Eigen::Vector2d const> const &last_left,
-        Eigen::Ref<Eigen::Vector2d const> const &last_right,
-        Eigen::Ref<Eigen::Vector2d const> const &new_left,
-        Eigen::Ref<Eigen::Vector2d const> const &new_right,
+        Eigen::Ref<Eigen::Vector2d const> last_left,
+        Eigen::Ref<Eigen::Vector2d const> last_right,
+        Eigen::Ref<Eigen::Vector2d const> new_left,
+        Eigen::Ref<Eigen::Vector2d const> new_right,
         Model::Balancelaw::Isothermaleulerequation const &bl, double diameter,
         double roughness);
   };

--- a/src/Model/Subproblem/include/Subproblem.hpp
+++ b/src/Model/Subproblem/include/Subproblem.hpp
@@ -26,12 +26,12 @@ namespace Model {
     // purely virtual functions:
     virtual void evaluate(
         Eigen::Ref<Eigen::VectorXd> rootvalues, double last_time,
-        double new_time, Eigen::Ref<Eigen::VectorXd const> const &last_state,
-        Eigen::Ref<Eigen::VectorXd const> const &new_state) const = 0;
+        double new_time, Eigen::Ref<Eigen::VectorXd const> last_state,
+        Eigen::Ref<Eigen::VectorXd const> new_state) const = 0;
     virtual void evaluate_state_derivative(
         Aux::Matrixhandler *jacobianhandler, double last_time, double new_time,
-        Eigen::Ref<Eigen::VectorXd const> const &,
-        Eigen::Ref<Eigen::VectorXd const> const &new_state) const = 0;
+        Eigen::Ref<Eigen::VectorXd const>,
+        Eigen::Ref<Eigen::VectorXd const> new_state) const = 0;
 
     virtual void save_values(double time, Eigen::Ref<Eigen::VectorXd> new_state)
         = 0;

--- a/src/Newtonsolver/Newtonsolver.cpp
+++ b/src/Newtonsolver/Newtonsolver.cpp
@@ -13,7 +13,7 @@ namespace Solver {
   template <typename Problemtype>
   void Newtonsolver_temp<Problemtype>::evaluate_state_derivative_triplets(
       Problemtype &problem, double last_time, double new_time,
-      Eigen::Ref<Eigen::VectorXd const> const &last_state,
+      Eigen::Ref<Eigen::VectorXd const> last_state,
       Eigen::Ref<Eigen::VectorXd> new_state) {
 
     {
@@ -31,8 +31,8 @@ namespace Solver {
   template <typename Problemtype>
   void Newtonsolver_temp<Problemtype>::evaluate_state_derivative_coeffref(
       Problemtype &problem, double last_time, double new_time,
-      Eigen::Ref<Eigen::VectorXd const> const &last_state,
-      Eigen::Ref<Eigen::VectorXd const> const &new_state) {
+      Eigen::Ref<Eigen::VectorXd const> last_state,
+      Eigen::Ref<Eigen::VectorXd const> new_state) {
     Aux::Coeffrefhandler handler(&jacobian);
     Aux::Coeffrefhandler *const handler_ptr = &handler;
     problem.evaluate_state_derivative(
@@ -48,7 +48,7 @@ namespace Solver {
   Solutionstruct Newtonsolver_temp<Problemtype>::solve(
       Eigen::Ref<Eigen::VectorXd> new_state, Problemtype &problem, bool newjac,
       double last_time, double new_time,
-      Eigen::Ref<Eigen::VectorXd const> const &last_state) {
+      Eigen::Ref<Eigen::VectorXd const> last_state) {
     Solutionstruct solstruct;
 
     Eigen::VectorXd rootvalues(new_state.size());

--- a/src/Newtonsolver/include/Newtonsolver.hpp
+++ b/src/Newtonsolver/include/Newtonsolver.hpp
@@ -42,7 +42,7 @@ namespace Solver {
 
     void evaluate_state_derivative_triplets(
         Problemtype &problem, double last_time, double new_time,
-        Eigen::Ref<Eigen::VectorXd const> const &last_state,
+        Eigen::Ref<Eigen::VectorXd const> last_state,
         Eigen::Ref<Eigen::VectorXd> new_state);
 
     /// \brief Computes the jacobian with the assumption that the sparsity
@@ -54,8 +54,8 @@ namespace Solver {
 
     void evaluate_state_derivative_coeffref(
         Problemtype &problem, double last_time, double new_time,
-        Eigen::Ref<Eigen::VectorXd const> const &last_state,
-        Eigen::Ref<Eigen::VectorXd const> const &new_state);
+        Eigen::Ref<Eigen::VectorXd const> last_state,
+        Eigen::Ref<Eigen::VectorXd const> new_state);
 
     /// \brief Returns the number of structurally non-zero indices of the
     /// jacobian.
@@ -71,7 +71,7 @@ namespace Solver {
     Solutionstruct solve(
         Eigen::Ref<Eigen::VectorXd> new_state, Problemtype &problem,
         bool newjac, double last_time, double new_time,
-        Eigen::Ref<Eigen::VectorXd const> const &last_state);
+        Eigen::Ref<Eigen::VectorXd const> last_state);
 
   private:
     /// Holds an instance of the actual solver, to save computation time it

--- a/tests/MockSubproblem.hpp
+++ b/tests/MockSubproblem.hpp
@@ -16,14 +16,14 @@ namespace GrazerTest {
     MOCK_METHOD(
         void, evaluate,
         ((Eigen::Ref<Eigen::VectorXd>), (double), (double),
-         (Eigen::Ref<Eigen::VectorXd const> const &),
-         (Eigen::Ref<Eigen::VectorXd const> const &)),
+         (Eigen::Ref<Eigen::VectorXd const>),
+         (Eigen::Ref<Eigen::VectorXd const>)),
         (const, override));
     MOCK_METHOD(
         void, evaluate_state_derivative,
         ((Aux::Matrixhandler *), (double), (double),
-         (Eigen::Ref<Eigen::VectorXd const> const &last_state),
-         (Eigen::Ref<Eigen::VectorXd const> const &new_state)),
+         (Eigen::Ref<Eigen::VectorXd const> last_state),
+         (Eigen::Ref<Eigen::VectorXd const> new_state)),
         (const, override));
     MOCK_METHOD(int, reserve_indices, (int const next_free_index), (override));
     MOCK_METHOD(

--- a/tests/include/TestProblem.hpp
+++ b/tests/include/TestProblem.hpp
@@ -24,16 +24,16 @@ namespace GrazerTest {
 
     void evaluate(
         Eigen::Ref<Eigen::VectorXd> rootvalues, double, double,
-        Eigen::Ref<Eigen::VectorXd const> const &,
-        Eigen::Ref<Eigen::VectorXd const> const &new_state) const {
+        Eigen::Ref<Eigen::VectorXd const>,
+        Eigen::Ref<Eigen::VectorXd const> new_state) const {
 
       rootvalues = f(new_state);
     };
 
     void evaluate_state_derivative(
         Aux::Matrixhandler *jacobianhandler, double, double,
-        Eigen::Ref<Eigen::VectorXd const> const &,
-        Eigen::Ref<Eigen::VectorXd const> const &new_state) const {
+        Eigen::Ref<Eigen::VectorXd const>,
+        Eigen::Ref<Eigen::VectorXd const> new_state) const {
 
       Eigen::SparseMatrix<double> mat = df(new_state);
       for (int k = 0; k < mat.outerSize(); ++k)


### PR DESCRIPTION
now we pass almost all Eigen::Vector... as Refs. This actually seems to give a small performance benefit and is probably the way the Eigen maintainers find the most appropriate