### PR TITLE
Generate general unit schema from unit maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@
 /output*
 build/**
 debug/**
+Debug
 release/**
 mingw/**
 noteworthy_results/**

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,8 @@ endif()
 enable_testing()
 
 # https://github.com/google/googletest/blob/master/googletest/README.md#visual-studio-dynamic-vs-static-runtimes
-set(gtest_force_shared_crt ON)
+# https://stackoverflow.com/a/12546288/6662425 "how to activate that flag" 
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 add_subdirectory(googletest)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ enable_testing()
 
 # https://github.com/google/googletest/blob/master/googletest/README.md#visual-studio-dynamic-vs-static-runtimes
 # https://stackoverflow.com/a/12546288/6662425 "how to activate that flag" 
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+set(gtest_force_shared_crt ON CACHE BOOL "Stop Windows from fiddling with the static/dynamic library include settings" FORCE)
 add_subdirectory(googletest)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,9 @@ if (BUILD_WITH_LIBCPP AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   message(STATUS "Will compile with libc++.")
 endif()
 enable_testing()
+
+# https://github.com/google/googletest/blob/master/googletest/README.md#visual-studio-dynamic-vs-static-runtimes
+set(gtest_force_shared_crt ON)
 add_subdirectory(googletest)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,9 +26,12 @@ if (BUILD_WITH_LIBCPP AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 endif()
 enable_testing()
 
+
 # https://github.com/google/googletest/blob/master/googletest/README.md#visual-studio-dynamic-vs-static-runtimes
-# https://stackoverflow.com/a/12546288/6662425 "how to activate that flag" 
-set(gtest_force_shared_crt ON CACHE BOOL "Stop Windows from fiddling with the static/dynamic library include settings" FORCE)
+# https://stackoverflow.com/a/12546288/6662425 "how to activate that flag"
+if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+  set(gtest_force_shared_crt ON CACHE BOOL "Make gtest compile the C standard libraries as DLLs, because MSVE requires that." FORCE)
+endif()
 add_subdirectory(googletest)
 
 

--- a/src/Auxillary/json_schema/make_schema.cpp
+++ b/src/Auxillary/json_schema/make_schema.cpp
@@ -45,8 +45,6 @@ namespace Aux::schema {
     return type::simple("string", title, description);
   }
 
-  json type::length() { return Aux::unit::length.get_schema(); }
-
   nlohmann::json make_list_schema_of(nlohmann::json const &element_schema) {
     return make_list_schema_of(element_schema, 0, 0);
   }

--- a/src/Auxillary/json_schema/make_schema.cpp
+++ b/src/Auxillary/json_schema/make_schema.cpp
@@ -45,7 +45,7 @@ namespace Aux::schema {
     return type::simple("string", title, description);
   }
 
-  json type::length() { return Aux::unit::get_length_schema(); }
+  json type::length() { return Aux::unit::get_schema(Aux::unit::length_units); }
 
   nlohmann::json make_list_schema_of(nlohmann::json const &element_schema) {
     return make_list_schema_of(element_schema, 0, 0);

--- a/src/Auxillary/json_schema/make_schema.cpp
+++ b/src/Auxillary/json_schema/make_schema.cpp
@@ -45,7 +45,7 @@ namespace Aux::schema {
     return type::simple("string", title, description);
   }
 
-  json type::length() { return Aux::unit::get_schema(Aux::unit::length_units); }
+  json type::length() { return Aux::unit::length.get_schema(); }
 
   nlohmann::json make_list_schema_of(nlohmann::json const &element_schema) {
     return make_list_schema_of(element_schema, 0, 0);

--- a/src/Auxillary/unit_conversion/CMakeLists.txt
+++ b/src/Auxillary/unit_conversion/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(aux_unit_conversion STATIC unit_conversion.cpp)
 
-target_link_libraries(aux_unit_conversion PRIVATE nlohmann_json)
+target_link_libraries(aux_unit_conversion PRIVATE nlohmann_json json_validation)
 
 target_include_directories(aux_unit_conversion PUBLIC include)

--- a/src/Auxillary/unit_conversion/include/unit_conversion.hpp
+++ b/src/Auxillary/unit_conversion/include/unit_conversion.hpp
@@ -4,30 +4,30 @@
 
 namespace Aux::unit {
 
-  class Conversion { // should really be a concept "Conversion"
-  public:
-    virtual double operator()(double value) = 0;
-  };
+  using nlohmann::json;
 
-  class Multiplicator : Conversion {
-    const double multiplicator;
-  public:
-    double operator()(double value);
-    Multiplicator(double multiplicator);
-  };
-
-  class FunctionConversion : Conversion {
+  class Conversion {
     const std::function<double(double)> conversion;
+
   public:
+    Conversion(double multiplicator);
+    Conversion(std::function<double(double)> conversion);
     double operator()(double value);
-    FunctionConversion(std::function<double(double)> conversion);
   };
 
   class Measure {
   public:
     const std::string name;
+
+  private:
     const std::map<std::string, Conversion> conversion_map;
-    Measure(std::string, std::map<std::string,Conversion>);
+
+  public:
+    Measure(
+        const std::string name,
+        const std::map<std::string, Conversion> conversion_map);
+    json get_schema() const;
+    double parse_to_si(json const unit) const;
   };
 
   extern const Measure length;
@@ -41,61 +41,6 @@ namespace Aux::unit {
   extern const Measure volume_flux;
   extern const Measure temperature;
 
-  extern const std::map<std::string, double> length_units;
-  extern const std::map<std::string, double> area_units;
-  extern const std::map<std::string, double> volume_units;
-  extern const std::map<std::string, double> pressure_units;
-  extern const std::map<std::string, double> frequency_units;
-  extern const std::map<std::string, double> force_units;
-  extern const std::map<std::string, double> power_units;
-  extern const std::map<std::string, double> mass_units;
-  extern const std::map<std::string, double> volume_flux_units;
-
-  // arbitrary lambda conversions
-  typedef std::function<double(double)> conversion;
-
-  // conversion instructions for temperature
-  extern const std::map<std::string, conversion> temperature_units;
-
-  using nlohmann::json;
-  json get_schema(Measure measure);
-
-  /**
-   * @brief In contrast to multiplicative conversions (e.g. feet to meter)
-   * temperature conversion is more complicated. To allow simple multiplication
-   * tables unit_conversion is overloaded to accept either a double or a lambda
-   * function.
-   *
-   * unit_conversion behaves like value*conv if conv is a double which covers
-   * most unit conversions.
-   *
-   * unit_conversion behaves like conv(value) if conv is a lambda which allows
-   * for arbitarily complicated conversion.
-   *
-   * @param value of the current unit
-   * @param conv multiplicator to get to the si-unit
-   * @return double si-unit
-   */
-  double unit_conversion(double value, double conv);
-
-  /**
-   * @brief In contrast to multiplicative conversions (e.g. feet to meter)
-   * temperature conversion is more complicated. To allow simple multiplication
-   * tables unit_conversion is overloaded to accept either a double or a lambda
-   * function.
-   *
-   * unit_conversion behaves like value*conv if conv is a double which covers
-   * most unit conversions.
-   *
-   * unit_conversion behaves like conv(value) if conv is a lambda which allows
-   * for arbitarily complicated conversion.
-   *
-   * @param value value which might have an arbitrary unit
-   * @param conv lambda function which returns the si-unit
-   * @return double si-unit
-   */
-  double unit_conversion(double value, conversion conv);
-
   /**
    * @brief parses a string which is the prefix of a unit (e.g. "500 k" of "500
    * km") returns the value of the number multiplied with the value of the
@@ -108,7 +53,7 @@ namespace Aux::unit {
    */
   double parse_prefix(
       std::string const &prefix,
-      std::map<std::string, double> const &prefix_map);
+      std::map<std::string, Conversion> const &prefix_map);
 
   /**
    * @brief parses a string which is the prefix of a unit (e.g. "500 k" of "500
@@ -120,38 +65,9 @@ namespace Aux::unit {
    */
   double parse_prefix_si(std::string const &prefix);
 
-  template <typename T>
-  const std::tuple<std::string, T> parse_unit(
-      std::string const &unit, std::map<std::string, T> const &unit_map) {
-    auto unit_size = unit.size();
-    for (auto const &[str_unit, val] : unit_map) {
-      auto symb_size = str_unit.size();
-      if (unit_size >= symb_size
-          and unit.compare(unit_size - symb_size, symb_size, str_unit)
-                  == 0) { // match
-        return std::tuple<std::string, T>(
-            unit.substr(0, unit.size() - symb_size), val);
-      }
-    }
-    std::ostringstream o;
-    o << "Could not find the unit of " << unit << " in the unit_map "
-      << "\n";
-    throw std::runtime_error(o.str());
-  }
+  const std::tuple<std::string, Conversion> parse_unit(
+      std::string const &unit,
+      std::map<std::string, Conversion> const &unit_map);
 
-  template <typename T>
-  double
-  parse_to_si(json const &unit_json, std::map<std::string, T> const &unit_map) {
-    std::string unit = unit_json["unit"].get<std::string>();
-
-    auto [prefix, conv] = parse_unit<T>(unit, unit_map);
-    return unit_conversion(
-        unit_json["value"].get<double>() * parse_prefix_si(prefix), conv);
-  }
-
-  extern template double parse_to_si<conversion>(
-      json const &unit_json, std::map<std::string, conversion> const &unit_map);
-
-  extern template double parse_to_si<double>(
-      json const &unit_json, std::map<std::string, double> const &unit_map);
+  std::string re_capture_from_map(std::map<std::string, Conversion> map);
 } // namespace Aux::unit

--- a/src/Auxillary/unit_conversion/include/unit_conversion.hpp
+++ b/src/Auxillary/unit_conversion/include/unit_conversion.hpp
@@ -3,10 +3,45 @@
 #include <sstream>
 
 namespace Aux::unit {
-  using nlohmann::json;
-  extern const std::map<std::string, double> length_units;
-  json get_length_schema();
 
+  class Conversion { // should really be a concept "Conversion"
+  public:
+    virtual double operator()(double value) = 0;
+  };
+
+  class Multiplicator : Conversion {
+    const double multiplicator;
+  public:
+    double operator()(double value);
+    Multiplicator(double multiplicator);
+  };
+
+  class FunctionConversion : Conversion {
+    const std::function<double(double)> conversion;
+  public:
+    double operator()(double value);
+    FunctionConversion(std::function<double(double)> conversion);
+  };
+
+  class Measure {
+  public:
+    const std::string name;
+    const std::map<std::string, Conversion> conversion_map;
+    Measure(std::string, std::map<std::string,Conversion>);
+  };
+
+  extern const Measure length;
+  extern const Measure area;
+  extern const Measure volume;
+  extern const Measure pressure;
+  extern const Measure frequency;
+  extern const Measure force;
+  extern const Measure power;
+  extern const Measure mass;
+  extern const Measure volume_flux;
+  extern const Measure temperature;
+
+  extern const std::map<std::string, double> length_units;
   extern const std::map<std::string, double> area_units;
   extern const std::map<std::string, double> volume_units;
   extern const std::map<std::string, double> pressure_units;
@@ -21,6 +56,9 @@ namespace Aux::unit {
 
   // conversion instructions for temperature
   extern const std::map<std::string, conversion> temperature_units;
+
+  using nlohmann::json;
+  json get_schema(Measure measure);
 
   /**
    * @brief In contrast to multiplicative conversions (e.g. feet to meter)

--- a/src/Auxillary/unit_conversion/include/unit_conversion.hpp
+++ b/src/Auxillary/unit_conversion/include/unit_conversion.hpp
@@ -14,11 +14,10 @@ namespace Aux::unit {
    * metres this is achieved by taking x->1000*x. Applying this conversion conv
    * = Conversion(1000) to a number x thus results in conv(x) = 1000*x
    *
-   * Conversions can constructed from doubles (which are interpreted as
-   * multiplicators as above) but also from general functions. For the
+   * Conversions can constructed from multiplicators (which are interpreted as
+   * multiplicators as above) but also from multiplicator+offsets. For the
    * conversion from fahrenheit to celcius for example one would need to supply
-   * a general f_to_c function. conv = Conversion(f_to_c) acts like the supplied
-   * function in this case: conv(x) = f_to_c(x).
+   * both a multiplicator and an offset.
    *
    * So the Conversion class allows the grouping of different conversion
    * methods only differening by the constructor they use.

--- a/src/Auxillary/unit_conversion/include/unit_conversion.hpp
+++ b/src/Auxillary/unit_conversion/include/unit_conversion.hpp
@@ -6,6 +6,24 @@ namespace Aux::unit {
 
   using nlohmann::json;
 
+  /**
+   * @brief Represents a Conversion of a value with one unit to the same value
+   * with a different unit
+   *
+   * @details Examples: a conversion might be the conversion from kilometres to
+   * metres this is achieved by taking x->1000*x. Applying this conversion conv
+   * = Conversion(1000) to a number x thus results in conv(x) = 1000*x
+   *
+   * Conversions can constructed from doubles (which are interpreted as
+   * multiplicators as above) but also from general functions. For the
+   * conversion from fahrenheit to celcius for example one would need to supply
+   * a general f_to_c function. conv = Conversion(f_to_c) acts like the supplied
+   * function in this case: conv(x) = f_to_c(x).
+   *
+   * So the Conversion class allows the grouping of different conversion
+   * methods only differening by the constructor they use.
+   *
+   */
   class Conversion {
     const std::function<double(double)> conversion;
 
@@ -15,6 +33,12 @@ namespace Aux::unit {
     double operator()(double value);
   };
 
+  /**
+   * @brief Represents a measue (e.g. length). One can access its name, parse
+   * json measurements to si units and get the json schema for such json
+   * measurements.
+   *
+   */
   class Measure {
   public:
     const std::string name;
@@ -26,8 +50,21 @@ namespace Aux::unit {
     Measure(
         const std::string name,
         const std::map<std::string, Conversion> conversion_map);
+    /**
+     * @brief Get the schema for a Json describing this Measurement
+     *
+     * @return json similar to {"value": {"type": "number"}, "unit": {"type":
+     * "string", "pattern": <some_regex>}}
+     */
     json get_schema() const;
-    double parse_to_si(json const unit) const;
+    /**
+     * @brief Converts a json measurement (described by the get_schema json schema)
+     * to si units
+     * 
+     * @param  json_measurement e.g. {"value": 123, "unit": "mm"}
+     * @return double (value in si units) e.g. 0.123
+     */
+    double parse_to_si(json const json_measurement) const;
   };
 
   extern const Measure length;

--- a/src/Auxillary/unit_conversion/include/unit_conversion.hpp
+++ b/src/Auxillary/unit_conversion/include/unit_conversion.hpp
@@ -25,11 +25,11 @@ namespace Aux::unit {
    *
    */
   class Conversion {
-    const std::function<double(double)> conversion;
+    const double multiplicator;
+    const double offset;
 
   public:
-    Conversion(double multiplicator);
-    Conversion(std::function<double(double)> conversion);
+    Conversion(double multiplicator, double offset=0);
     double operator()(double value);
   };
 

--- a/src/Auxillary/unit_conversion/include/unit_conversion.hpp
+++ b/src/Auxillary/unit_conversion/include/unit_conversion.hpp
@@ -58,9 +58,9 @@ namespace Aux::unit {
      */
     json get_schema() const;
     /**
-     * @brief Converts a json measurement (described by the get_schema json schema)
-     * to si units
-     * 
+     * @brief Converts a json measurement (described by the get_schema json
+     * schema) to si units
+     *
      * @param  json_measurement e.g. {"value": 123, "unit": "mm"}
      * @return double (value in si units) e.g. 0.123
      */

--- a/src/Auxillary/unit_conversion/include/unit_conversion.hpp
+++ b/src/Auxillary/unit_conversion/include/unit_conversion.hpp
@@ -29,7 +29,7 @@ namespace Aux::unit {
     const double offset;
 
   public:
-    Conversion(double multiplicator, double offset=0);
+    Conversion(double multiplicator, double offset = 0);
     double operator()(double value);
   };
 

--- a/src/Auxillary/unit_conversion/include/unit_conversion.hpp
+++ b/src/Auxillary/unit_conversion/include/unit_conversion.hpp
@@ -30,7 +30,7 @@ namespace Aux::unit {
 
   public:
     Conversion(double multiplicator, double offset = 0);
-    double operator()(double value);
+    double operator()(double value) const;
   };
 
   /**

--- a/src/Auxillary/unit_conversion/unit_conversion.cpp
+++ b/src/Auxillary/unit_conversion/unit_conversion.cpp
@@ -96,14 +96,11 @@ namespace Aux::unit {
     return parse_prefix(prefix, si_prefixes);
   }
 
-  Conversion::Conversion(double multiplicator) :
-      conversion([multiplicator](double x) { return x * multiplicator; }) {}
-
-  Conversion::Conversion(std::function<double(double)> conv) :
-      conversion(conv) {}
+  Conversion::Conversion(double _multiplicator, double _offset) :
+      multiplicator(_multiplicator), offset(_offset) {}
 
   double Conversion::operator()(double value) {
-    return this->conversion(value);
+    return multiplicator * value + offset;
   }
 
   Measure::Measure(

--- a/src/Auxillary/unit_conversion/unit_conversion.cpp
+++ b/src/Auxillary/unit_conversion/unit_conversion.cpp
@@ -97,7 +97,7 @@ namespace Aux::unit {
   Conversion::Conversion(double _multiplicator, double _offset) :
       multiplicator(_multiplicator), offset(_offset) {}
 
-  double Conversion::operator()(double value) {
+  double Conversion::operator()(double value) const {
     return multiplicator * value + offset;
   }
 

--- a/src/Auxillary/unit_conversion/unit_conversion.cpp
+++ b/src/Auxillary/unit_conversion/unit_conversion.cpp
@@ -1,8 +1,8 @@
 #include <unit_conversion.hpp>
 
+#include <json_validation.hpp>
 #include <map>
 #include <sstream>
-#include <json_validation.hpp>
 
 namespace Aux::unit {
   const Measure length{

--- a/src/Auxillary/unit_conversion/unit_conversion.cpp
+++ b/src/Auxillary/unit_conversion/unit_conversion.cpp
@@ -45,12 +45,10 @@ namespace Aux::unit {
 
   const Measure temperature{
       "temperature",
-      {{"K", Conversion([](double x) { return x; })},
-       {"C", Conversion([](double x) { return x + 273.15; })},
-       {"Celsius", Conversion([](double x) { return x + 273.15; })},
-       {"F", Conversion([](double x) {
-          return x * 5.0 / 9.0 + 459.67 * 5.0 / 9.0;
-        })}}};
+      {{"K", Conversion(1)},
+       {"C", Conversion(1, 273.15)},
+       {"Celsius", Conversion(1, 273.15)},
+       {"F", Conversion(5.0 / 9.0, 459.67 * 5.0 / 9.0)}}};
 
   // https://en.wikipedia.org/wiki/Metric_prefix#List_of_SI_prefixes
   const std::map<std::string, Conversion> si_prefixes{

--- a/src/Auxillary/unit_conversion/unit_conversion.cpp
+++ b/src/Auxillary/unit_conversion/unit_conversion.cpp
@@ -2,6 +2,7 @@
 
 #include <map>
 #include <sstream>
+#include <json_validation.hpp>
 
 namespace Aux::unit {
   const Measure length{
@@ -110,11 +111,12 @@ namespace Aux::unit {
       const std::map<std::string, Conversion> conv_map) :
       name(provided_name), conversion_map(conv_map) {}
 
-  double Measure::parse_to_si(json const unit_json) const {
-    std::string unit = unit_json["unit"].get<std::string>();
+  double Measure::parse_to_si(json const measurement) const {
+    validation::validate_json(measurement, this->get_schema());
+    std::string unit = measurement["unit"].get<std::string>();
 
     auto [prefix, conv] = parse_unit(unit, this->conversion_map);
-    return conv(unit_json["value"].get<double>() * parse_prefix_si(prefix));
+    return conv(measurement["value"].get<double>() * parse_prefix_si(prefix));
   }
 
   const std::tuple<std::string, Conversion> parse_unit(

--- a/src/Auxillary/unit_conversion/unit_conversion.cpp
+++ b/src/Auxillary/unit_conversion/unit_conversion.cpp
@@ -4,6 +4,31 @@
 #include <sstream>
 
 namespace Aux::unit {
+  double Multiplicator::operator()(double value) {
+    return this->multiplicator * value;
+  }
+  Multiplicator::Multiplicator(double multiplicator) :
+      multiplicator(multiplicator) {}
+
+  double FunctionConversion::operator()(double value) {
+    return this->conversion(value);
+  }
+  FunctionConversion::FunctionConversion(
+      std::function<double(double)> conversion) :
+      conversion(conversion) {}
+
+  Measure::Measure(
+      std::string name, std::map<std::string, Conversion> conversion_map) :
+      name(name), conversion_map(conversion_map) {}
+
+  const Measure length
+      = {"length", std::map<std::string, Conversion>(
+                       {{"m", Multiplicator(1.0)},
+                        {"in", Multiplicator(0.0254)},
+                        {"ft", Multiplicator(0.3048)},
+                        {"yd", Multiplicator(0.9144)},
+                        {"mi", Multiplicator(1609.344)}})};
+
   // convert double to boost::units::quantity<si::length> add "*si::meters" to
   // the entries
   const std::map<std::string, double> length_units{
@@ -12,28 +37,6 @@ namespace Aux::unit {
       {"ft", 0.3048},
       {"yd", 0.9144},
       {"mi", 1609.344}};
-  json get_length_schema() {
-    json type_schema;
-    type_schema["type"] = "object";
-    type_schema["description"] = "Length Measurement";
-    type_schema["required"] = {"value", "unit"};
-    type_schema["additionalProperties"] = false;
-    type_schema["properties"]["unit"]["type"] = "string";
-    json pattern1;
-    pattern1["pattern"]
-        = "^(Y|Z|E|P|T|G|M|k|h|da|d|c|m|mu|n|p|f|a|z|y)?(m|ft|"
-          "in|"
-          "yd|mi)$";
-    type_schema["properties"]["unit"]["oneOf"].push_back(pattern1);
-    json pattern2;
-    pattern2["pattern"]
-        = "^([0-9]*(\\.[0-9]+)? "
-          ")(Y|Z|E|P|T|G|M|k|h|da|d|c|m|mu||n|"
-          "p|f|a|z|y)?(m|ft|in|yd|mi)$";
-    type_schema["properties"]["unit"]["oneOf"].push_back(pattern2);
-    type_schema["properties"]["value"]["type"] = "number";
-    return type_schema;
-  }
 
   const std::map<std::string, double> area_units{
       {"m^2", 1.0}, {"ac", 4046.9}, {"acre", 4046.9}};
@@ -74,6 +77,37 @@ namespace Aux::unit {
       {"", 1},     {"d", 0.1},   {"c", 1e-2},  {"m", 1e-3},  {"mu", 1e-6},
       {"n", 1e-9}, {"p", 1e-12}, {"f", 1e-15}, {"a", 1e-18}, {"z", 1e-21},
       {"y", 1e-24}};
+
+  template<typename T>
+  std::string re_capture_from_map(std::map<std::string, T> map) {
+    std::ostringstream regex_stream;
+    regex_stream << "(";
+    for (auto [item, _] : map) { regex_stream << item << "|"; }
+    std::string regex = regex_stream.str();
+    regex.pop_back();
+    return regex + ")";
+  }
+
+  json get_schema(Measure measure) {
+    json type_schema;
+    type_schema["type"] = "object";
+    type_schema["description"] = measure.name + "Measurement";
+    type_schema["required"] = {"value", "unit"};
+    type_schema["additionalProperties"] = false;
+    type_schema["properties"]["unit"]["type"] = "string";
+    type_schema["properties"]["value"]["type"] = "number";
+
+    std::string simple_pattern = re_capture_from_map(si_prefixes) + "?"
+                                 + re_capture_from_map(measure.conversion_map)
+                                 + "$";
+    json pattern1;
+    pattern1["pattern"] = "^" + simple_pattern;
+    json pattern2;
+    pattern2["pattern"] = "^([0-9]*(\\.[0-9]+)? )" + simple_pattern;
+    type_schema["properties"]["unit"]["oneOf"].push_back(pattern1);
+    type_schema["properties"]["unit"]["oneOf"].push_back(pattern2);
+    return type_schema;
+  }
 
   double unit_conversion(double value, double unit) { return value * unit; }
 

--- a/src/Auxillary/unit_conversion/unit_conversion.cpp
+++ b/src/Auxillary/unit_conversion/unit_conversion.cpp
@@ -4,118 +4,64 @@
 #include <sstream>
 
 namespace Aux::unit {
-  double Multiplicator::operator()(double value) {
-    return this->multiplicator * value;
-  }
-  Multiplicator::Multiplicator(double multiplicator) :
-      multiplicator(multiplicator) {}
+  const Measure length{
+      "length",
+      {{"m", 1.0},
+       {"in", 0.0254},
+       {"ft", 0.3048},
+       {"yd", 0.9144},
+       {"mi", 1609.344}}};
 
-  double FunctionConversion::operator()(double value) {
-    return this->conversion(value);
-  }
-  FunctionConversion::FunctionConversion(
-      std::function<double(double)> conversion) :
-      conversion(conversion) {}
+  const Measure area{"area", {{"m^2", 1.0}, {"ac", 4046.9}, {"acre", 4046.9}}};
 
-  Measure::Measure(
-      std::string name, std::map<std::string, Conversion> conversion_map) :
-      name(name), conversion_map(conversion_map) {}
+  const Measure volume{
+      "volume",
+      {
+          {"m^3", 1.0},
+          {"L", 1e-3},
+          {"l", 1e-3},
+      }};
 
-  const Measure length
-      = {"length", std::map<std::string, Conversion>(
-                       {{"m", Multiplicator(1.0)},
-                        {"in", Multiplicator(0.0254)},
-                        {"ft", Multiplicator(0.3048)},
-                        {"yd", Multiplicator(0.9144)},
-                        {"mi", Multiplicator(1609.344)}})};
+  const Measure pressure{
+      "pressure",
+      {{"Pa", 1.0}, {"bar", 1e5}, {"atm", 101325}, {"psi", 6894.757}}};
 
-  // convert double to boost::units::quantity<si::length> add "*si::meters" to
-  // the entries
-  const std::map<std::string, double> length_units{
-      {"m", 1.0},
-      {"in", 0.0254},
-      {"ft", 0.3048},
-      {"yd", 0.9144},
-      {"mi", 1609.344}};
+  const Measure frequency{
+      "frequency",
+      {{"Hz", 1.0}, {"per_min", 1.0 / 60.0}, {"per_minute", 1.0 / 60.0}}};
 
-  const std::map<std::string, double> area_units{
-      {"m^2", 1.0}, {"ac", 4046.9}, {"acre", 4046.9}};
+  const Measure force{"force", {{"N", 1.0}}};
 
-  const std::map<std::string, double> volume_units{
-      {"m^3", 1.0},
-      {"L", 1e-3},
-      {"l", 1e-3},
-  };
+  const Measure power{"power", {{"W", 1.0}, {"PS", 735.49875}}};
 
-  const std::map<std::string, double> pressure_units{
-      {"Pa", 1.0}, {"bar", 1e5}, {"atm", 101325}, {"psi", 6894.757}};
+  const Measure mass{
+      "mass",
+      {{"g", 0.001}, {"t", 1000}, {"oz", 0.028349523125}, {"lb", 0.45359237}}};
 
-  const std::map<std::string, double> frequency_units{
-      {"Hz", 1.0}, {"per_min", 1.0 / 60.0}, {"per_minute", 1.0 / 60.0}};
+  const Measure volume_flux{
+      "volume",
+      {{"m_cube_per_s", 1.0}, {"1000m_cube_per_hour", 1000.0 / 3600.0}}};
 
-  const std::map<std::string, double> force_units{{"N", 1.0}};
-
-  const std::map<std::string, double> power_units{
-      {"W", 1.0}, {"PS", 735.49875}};
-
-  const std::map<std::string, double> mass_units{
-      {"g", 0.001}, {"t", 1000}, {"oz", 0.028349523125}, {"lb", 0.45359237}};
-
-  const std::map<std::string, double> volume_flux_units{
-      {"m_cube_per_s", 1.0}, {"1000m_cube_per_hour", 1000.0 / 3600.0}};
-
-  const std::map<std::string, conversion> temperature_units{
-      {"K", [](double x) { return x; }},
-      {"C", [](double x) { return x + 273.15; }},
-      {"Celsius", [](double x) { return x + 273.15; }},
-      {"F", [](double x) { return x * 5.0 / 9.0 + 459.67 * 5.0 / 9.0; }}};
+  const Measure temperature{
+      "temperature",
+      {{"K", Conversion([](double x) { return x; })},
+       {"C", Conversion([](double x) { return x + 273.15; })},
+       {"Celsius", Conversion([](double x) { return x + 273.15; })},
+       {"F", Conversion([](double x) {
+          return x * 5.0 / 9.0 + 459.67 * 5.0 / 9.0;
+        })}}};
 
   // https://en.wikipedia.org/wiki/Metric_prefix#List_of_SI_prefixes
-  const std::map<std::string, double> si_prefixes{
+  const std::map<std::string, Conversion> si_prefixes{
       {"Y", 1e24}, {"Z", 1e21},  {"E", 1e18},  {"P", 1e15},  {"T", 1e12},
       {"G", 1e9},  {"M", 1e6},   {"k", 1e3},   {"h", 100},   {"da", 10},
       {"", 1},     {"d", 0.1},   {"c", 1e-2},  {"m", 1e-3},  {"mu", 1e-6},
       {"n", 1e-9}, {"p", 1e-12}, {"f", 1e-15}, {"a", 1e-18}, {"z", 1e-21},
       {"y", 1e-24}};
 
-  template<typename T>
-  std::string re_capture_from_map(std::map<std::string, T> map) {
-    std::ostringstream regex_stream;
-    regex_stream << "(";
-    for (auto [item, _] : map) { regex_stream << item << "|"; }
-    std::string regex = regex_stream.str();
-    regex.pop_back();
-    return regex + ")";
-  }
-
-  json get_schema(Measure measure) {
-    json type_schema;
-    type_schema["type"] = "object";
-    type_schema["description"] = measure.name + "Measurement";
-    type_schema["required"] = {"value", "unit"};
-    type_schema["additionalProperties"] = false;
-    type_schema["properties"]["unit"]["type"] = "string";
-    type_schema["properties"]["value"]["type"] = "number";
-
-    std::string simple_pattern = re_capture_from_map(si_prefixes) + "?"
-                                 + re_capture_from_map(measure.conversion_map)
-                                 + "$";
-    json pattern1;
-    pattern1["pattern"] = "^" + simple_pattern;
-    json pattern2;
-    pattern2["pattern"] = "^([0-9]*(\\.[0-9]+)? )" + simple_pattern;
-    type_schema["properties"]["unit"]["oneOf"].push_back(pattern1);
-    type_schema["properties"]["unit"]["oneOf"].push_back(pattern2);
-    return type_schema;
-  }
-
-  double unit_conversion(double value, double unit) { return value * unit; }
-
-  double unit_conversion(double value, conversion conv) { return conv(value); }
-
   double parse_prefix(
       std::string const &prefix,
-      std::map<std::string, double> const &prefix_map) {
+      std::map<std::string, Conversion> const &prefix_map) {
     // split into num_prefix and si_prefix
     std::string si_prefix;
     double num_prefix;
@@ -141,15 +87,82 @@ namespace Aux::unit {
       o << "Unknown si prefix: " << si_prefix << "\n";
       throw std::runtime_error(o.str());
     }
-    return num_prefix * search_si_prefix->second;
+    Conversion conv = search_si_prefix->second;
+    return conv(num_prefix);
   }
 
   double parse_prefix_si(std::string const &prefix) {
     return parse_prefix(prefix, si_prefixes);
   }
 
-  template double parse_to_si<conversion>(
-      json const &unit_json, std::map<std::string, conversion> const &unit_map);
-  template double parse_to_si<double>(
-      json const &unit_json, std::map<std::string, double> const &unit_map);
+  Conversion::Conversion(double multiplicator) :
+      conversion([multiplicator](double x) { return x * multiplicator; }) {}
+
+  Conversion::Conversion(std::function<double(double)> conv) :
+      conversion(conv) {}
+
+  double Conversion::operator()(double value) {
+    return this->conversion(value);
+  }
+
+  Measure::Measure(
+      const std::string provided_name,
+      const std::map<std::string, Conversion> conv_map) :
+      name(provided_name), conversion_map(conv_map) {}
+
+  double Measure::parse_to_si(json const unit_json) const {
+    std::string unit = unit_json["unit"].get<std::string>();
+
+    auto [prefix, conv] = parse_unit(unit, this->conversion_map);
+    return conv(unit_json["value"].get<double>() * parse_prefix_si(prefix));
+  }
+
+  const std::tuple<std::string, Conversion> parse_unit(
+      std::string const &unit,
+      std::map<std::string, Conversion> const &unit_map) {
+    auto unit_size = unit.size();
+    for (auto const &[str_unit, val] : unit_map) {
+      auto symb_size = str_unit.size();
+      if (unit_size >= symb_size
+          and unit.compare(unit_size - symb_size, symb_size, str_unit)
+                  == 0) { // match
+        return std::tuple<std::string, Conversion>(
+            unit.substr(0, unit.size() - symb_size), val);
+      }
+    }
+    std::ostringstream o;
+    o << "Could not find the unit of " << unit << " in the unit_map "
+      << "\n";
+    throw std::runtime_error(o.str());
+  }
+
+  json Measure::get_schema() const {
+    json type_schema;
+    type_schema["type"] = "object";
+    type_schema["description"] = this->name + "Measurement";
+    type_schema["required"] = {"value", "unit"};
+    type_schema["additionalProperties"] = false;
+    type_schema["properties"]["unit"]["type"] = "string";
+    type_schema["properties"]["value"]["type"] = "number";
+
+    std::string simple_pattern = re_capture_from_map(si_prefixes) + "?"
+                                 + re_capture_from_map(this->conversion_map)
+                                 + "$";
+    json pattern1;
+    pattern1["pattern"] = "^" + simple_pattern;
+    json pattern2;
+    pattern2["pattern"] = "^([0-9]*(\\.[0-9]+)? )" + simple_pattern;
+    type_schema["properties"]["unit"]["oneOf"].push_back(pattern1);
+    type_schema["properties"]["unit"]["oneOf"].push_back(pattern2);
+    return type_schema;
+  }
+  std::string re_capture_from_map(std::map<std::string, Conversion> map) {
+    std::ostringstream regex_stream;
+    regex_stream << "(";
+    for (auto [item, _] : map) { regex_stream << item << "|"; }
+    std::string regex = regex_stream.str();
+    regex.pop_back();
+    return regex + ")";
+  }
+
 } // namespace Aux::unit

--- a/src/Auxillary/unit_conversion/unit_conversion.cpp
+++ b/src/Auxillary/unit_conversion/unit_conversion.cpp
@@ -153,7 +153,7 @@ namespace Aux::unit {
     json pattern1;
     pattern1["pattern"] = "^" + simple_pattern;
     json pattern2;
-    pattern2["pattern"] = "^([0-9]*(\\.[0-9]+)? )" + simple_pattern;
+    pattern2["pattern"] = "^([0-9]*(\\.[0-9]+)?(e-?[0-9]+)? )" + simple_pattern;
     type_schema["properties"]["unit"]["oneOf"].push_back(pattern1);
     type_schema["properties"]["unit"]["oneOf"].push_back(pattern2);
     return type_schema;

--- a/src/Model/Networkproblem/Gas/Pipe.cpp
+++ b/src/Model/Networkproblem/Gas/Pipe.cpp
@@ -22,12 +22,14 @@ namespace Model::Networkproblem::Gas {
   std::string Pipe::get_type() { return "Pipe"; }
   std::string Pipe::get_gas_type() const { return get_type(); }
 
+  namespace unit = Aux::unit;
+
   nlohmann::json Pipe::get_schema() {
     nlohmann::json schema = Network::Edge::get_schema();
 
-    Aux::schema::add_required(schema, "length", Aux::schema::type::length());
-    Aux::schema::add_required(schema, "diameter", Aux::schema::type::length());
-    Aux::schema::add_required(schema, "roughness", Aux::schema::type::length());
+    Aux::schema::add_required(schema, "length", unit::length.get_schema());
+    Aux::schema::add_required(schema, "diameter", unit::length.get_schema());
+    Aux::schema::add_required(schema, "roughness", unit::length.get_schema());
 
     Aux::schema::add_required(
         schema, "desired_delta_x", Aux::schema::type::number());
@@ -39,15 +41,15 @@ namespace Model::Networkproblem::Gas {
       nlohmann::json const &topology,
       std::vector<std::unique_ptr<Network::Node>> &nodes) :
       Network::Edge(topology, nodes),
-      diameter(Aux::unit::length.parse_to_si(topology["diameter"])),
-      roughness(Aux::unit::length.parse_to_si(topology["roughness"])),
+      diameter(unit::length.parse_to_si(topology["diameter"])),
+      roughness(unit::length.parse_to_si(topology["roughness"])),
       number_of_points(
           static_cast<int>(std::ceil(
-              Aux::unit::length.parse_to_si(topology["length"])
+              unit::length.parse_to_si(topology["length"])
               / topology["desired_delta_x"].get<double>()))
           + 1),
       Delta_x(
-          Aux::unit::length.parse_to_si(topology["length"])
+          unit::length.parse_to_si(topology["length"])
           / (number_of_points - 1)) {}
 
   void Pipe::evaluate(

--- a/src/Model/Networkproblem/Gas/Pipe.cpp
+++ b/src/Model/Networkproblem/Gas/Pipe.cpp
@@ -39,18 +39,15 @@ namespace Model::Networkproblem::Gas {
       nlohmann::json const &topology,
       std::vector<std::unique_ptr<Network::Node>> &nodes) :
       Network::Edge(topology, nodes),
-      diameter(Aux::unit::parse_to_si(
-          topology["diameter"], Aux::unit::length_units)),
-      roughness(Aux::unit::parse_to_si(
-          topology["roughness"], Aux::unit::length_units)),
+      diameter(Aux::unit::length.parse_to_si(topology["diameter"])),
+      roughness(Aux::unit::length.parse_to_si(topology["roughness"])),
       number_of_points(
           static_cast<int>(std::ceil(
-              Aux::unit::parse_to_si(
-                  topology["length"], Aux::unit::length_units)
+              Aux::unit::length.parse_to_si(topology["length"])
               / topology["desired_delta_x"].get<double>()))
           + 1),
       Delta_x(
-          Aux::unit::parse_to_si(topology["length"], Aux::unit::length_units)
+          Aux::unit::length.parse_to_si(topology["length"])
           / (number_of_points - 1)) {}
 
   void Pipe::evaluate(

--- a/src/validation/json_validation.cpp
+++ b/src/validation/json_validation.cpp
@@ -46,7 +46,8 @@ void validation::validate_json(json const &data, json const &schema) {
     validator.set_root_schema(schema);
   } catch (const std::exception &e) {
     std::ostringstream o;
-    o << "Validation of schema failed, here is why: " << e.what() << "\n";
+    o << "Couldn't validate the data, because the schema itself if faulty: "
+      << e.what() << "\n";
     throw std::runtime_error(o.str());
   }
 
@@ -55,7 +56,7 @@ void validation::validate_json(json const &data, json const &schema) {
     validator.validate(data);
   } catch (const std::exception &e) {
     std::ostringstream o;
-    o << "Validation failed: \n" << e.what() << "\n";
+    o << "The data does not conform to the schema: \n" << e.what() << "\n";
     throw std::runtime_error(o.str());
   }
 

--- a/tests/Auxillary/unit_conversion/AuxUnitConversionTest.cpp
+++ b/tests/Auxillary/unit_conversion/AuxUnitConversionTest.cpp
@@ -17,13 +17,12 @@ TEST(unitParser, parsingWorks) {
   json ten_thousand_micro_metres_1000
       = json::parse("{\"value\": 1000,\"unit\": \"1e4 mum\"}");
 
-  auto si_length = unit::parse_to_si(metres_10, unit::length_units);
+  auto si_length = unit::length.parse_to_si(metres_10);
 
   EXPECT_EQ(si_length, 10.0);
-  EXPECT_EQ(si_length, unit::parse_to_si(deca_metres_1, unit::length_units));
+  EXPECT_EQ(si_length, unit::length.parse_to_si(deca_metres_1));
   EXPECT_EQ(
-      si_length,
-      unit::parse_to_si(ten_thousand_micro_metres_1000, unit::length_units));
+      si_length, unit::length.parse_to_si(ten_thousand_micro_metres_1000));
 
   json celcius = R"({
     "value": 1,
@@ -40,54 +39,46 @@ TEST(unitParser, parsingWorks) {
   })"_json;
 
   EXPECT_EQ(
-      unit::parse_to_si(celcius, unit::temperature_units),
-      unit::parse_to_si(celcius_in_kelvin, unit::temperature_units));
+      unit::temperature.parse_to_si(celcius),
+      unit::temperature.parse_to_si(celcius_in_kelvin));
   EXPECT_EQ(
-      unit::parse_to_si(celcius, unit::temperature_units),
-      unit::parse_to_si(celcius_in_fahrenheit, unit::temperature_units));
+      unit::temperature.parse_to_si(celcius),
+      unit::temperature.parse_to_si(celcius_in_fahrenheit));
 }
 
 TEST(unitParser, mostUsedUnits) {
   EXPECT_EQ(
-      unit::parse_to_si(
-          R"({"value": 0.1, "unit":"bar"})"_json, unit::pressure_units),
+      unit::pressure.parse_to_si(R"({"value": 0.1, "unit":"bar"})"_json),
       1e4 // Pa
   );
   EXPECT_EQ(
-      unit::parse_to_si(
-          R"({"value": 2, "unit":"Celsius"})"_json, unit::temperature_units),
+      unit::temperature.parse_to_si(R"({"value": 2, "unit":"Celsius"})"_json),
       275.15 // K
   );
   EXPECT_EQ(
-      unit::parse_to_si(
-          R"({"value": 234, "unit":"K"})"_json, unit::temperature_units),
+      unit::temperature.parse_to_si(R"({"value": 234, "unit":"K"})"_json),
       234 // K
   );
   EXPECT_EQ(
-      unit::parse_to_si(
-          R"({"value": 23, "unit":"km"})"_json, unit::length_units),
+      unit::length.parse_to_si(R"({"value": 23, "unit":"km"})"_json),
       23000 // m
   );
   EXPECT_EQ(
-      unit::parse_to_si(
-          R"({"value": 100, "unit": "mm"})"_json, unit::length_units),
+      unit::length.parse_to_si(R"({"value": 100, "unit": "mm"})"_json),
       0.1 // m
   );
   EXPECT_EQ(
-      unit::parse_to_si(
-          R"({"value": 23, "unit":"kW"})"_json, unit::power_units),
+      unit::power.parse_to_si(R"({"value": 23, "unit":"kW"})"_json),
       23000 // W
   );
   EXPECT_EQ(
-      unit::parse_to_si(
-          R"({"value": 1000, "unit": "m_cube_per_s"})"_json,
-          unit::volume_flux_units),
-      unit::parse_to_si(
-          R"({"value": 3600, "unit": "1000m_cube_per_hour"})"_json,
-          unit::volume_flux_units));
+      unit::volume_flux.parse_to_si(
+          R"({"value": 1000, "unit": "m_cube_per_s"})"_json),
+
+      unit::volume_flux.parse_to_si(
+          R"({"value": 3600, "unit": "1000m_cube_per_hour"})"_json));
   EXPECT_EQ(
-      unit::parse_to_si(
-          R"({"value": 60, "unit": "per_min"})"_json, unit::frequency_units),
+      unit::frequency.parse_to_si(R"({"value": 60, "unit": "per_min"})"_json),
       1.0 // Hz
   );
 }


### PR DESCRIPTION
Rewrite Unit maps into `Measure` classes which have a `get_schema()` and parse_to_si helper function