### PR TITLE
disable warning of missing defaults in switch statements in tests dir

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -65,7 +65,7 @@ jobs:
           compiler: clang++
           build_type: Debug
           binary-path: /build/src/Grazer/grazer
-          dep-install: brew install bash metis ninja pkg-config; echo "/usr/local/bin" >> $GITHUB_PATH; echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> $GITHUB_ENV; echo "FC=gfortran-11" >> $GITHUB_ENV;
+          dep-install: brew install bash metis ninja pkg-config; echo "/usr/local/bin" >> $GITHUB_PATH; echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> $GITHUB_ENV; echo "FC=gfortran-14" >> $GITHUB_ENV;
           generator-command: -G"Ninja"
         - name: Release-Test
           os: ubuntu-22.04

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -65,7 +65,7 @@ jobs:
           compiler: clang++
           build_type: Debug
           binary-path: /build/src/Grazer/grazer
-          dep-install: brew install bash metis ninja pkg-config; echo "/usr/local/bin" >> $GITHUB_PATH; echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> $GITHUB_ENV; echo "FC=gfortran-14" >> $GITHUB_ENV;
+          dep-install: brew install bash metis ninja pkg-config; echo "/usr/local/bin" >> $GITHUB_PATH; echo "FC=gfortran-14" >> $GITHUB_ENV;
           generator-command: -G"Ninja"
         - name: Release-Test
           os: ubuntu-22.04

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -61,7 +61,7 @@ jobs:
           binary-path: /build/src/Grazer/grazer
           generator-command: -G"Ninja"
         - name: MacOS-Clang
-          os: macos-14
+          os: macos-latest
           compiler: clang++
           build_type: Debug
           binary-path: /build/src/Grazer/grazer
@@ -82,7 +82,8 @@ jobs:
       CTEST_OUTPUT_ON_FAILURE: 1
       BUILD_WITH_LIBCPP: ${{ matrix.build_with_libcpp }}
       # acts like a ternary:
-      CCACHE_OPTIONS: ${{'-D CMAKE_CXX_COMPILER_LAUNCHER=ccache -D CMAKE_C_COMPILER_LAUNCHER=ccache'}}
+      # CCACHE_OPTIONS: ${{'-D CMAKE_CXX_COMPILER_LAUNCHER=ccache -D CMAKE_C_COMPILER_LAUNCHER=ccache'}}
+
     # The CMake configure and build commands are platform agnostic and should work equally
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
@@ -95,10 +96,10 @@ jobs:
       with:
         submodules: recursive
     
-    - name: Set_up_CCache
-      uses: hendrikmuhs/ccache-action@v1 
-      with:
-        key: ${{ matrix.name }}
+    # - name: Set_up_CCache
+    #   uses: hendrikmuhs/ccache-action@v1 
+    #   with:
+    #     key: ${{ matrix.name }}
 
 
     - name: Install_Dependencies

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -82,8 +82,7 @@ jobs:
       CTEST_OUTPUT_ON_FAILURE: 1
       BUILD_WITH_LIBCPP: ${{ matrix.build_with_libcpp }}
       # acts like a ternary:
-      # CCACHE_OPTIONS: ${{'-D CMAKE_CXX_COMPILER_LAUNCHER=ccache -D CMAKE_C_COMPILER_LAUNCHER=ccache'}}
-
+      CCACHE_OPTIONS: ${{'-D CMAKE_CXX_COMPILER_LAUNCHER=ccache -D CMAKE_C_COMPILER_LAUNCHER=ccache'}}
     # The CMake configure and build commands are platform agnostic and should work equally
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
@@ -96,10 +95,10 @@ jobs:
       with:
         submodules: recursive
     
-    # - name: Set_up_CCache
-    #   uses: hendrikmuhs/ccache-action@v1 
-    #   with:
-    #     key: ${{ matrix.name }}
+    - name: Set_up_CCache
+      uses: hendrikmuhs/ccache-action@v1 
+      with:
+        key: ${{ matrix.name }}
 
 
     - name: Install_Dependencies

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,6 +17,9 @@ jobs:
         clang-format-version: "16"
     
 
+  # 2024.12.22: I disabled the macos pipeline because of hard-to-debug errors
+  # with the arm macos runner. If you have a mac and know how to reinstate a
+  # working macos runner, feel free to do so!
   build-and-test:
     if: github.event.pull_request.draft == false
     strategy:
@@ -27,7 +30,6 @@ jobs:
         - Linux-GNU
         - Linux-Clang
         - Linux-Clang-libc++
-        - MacOS-Clang
         - Release-Test
         include:
         - name: Linux-Docs
@@ -59,13 +61,6 @@ jobs:
           build_type: Debug
           build_with_libcpp: ON
           binary-path: /build/src/Grazer/grazer
-          generator-command: -G"Ninja"
-        - name: MacOS-Clang
-          os: macos-latest
-          compiler: clang++
-          build_type: Debug
-          binary-path: /build/src/Grazer/grazer
-          dep-install: brew install bash metis ninja pkg-config; echo "/usr/local/bin" >> $GITHUB_PATH; echo "FC=gfortran-14" >> $GITHUB_ENV;
           generator-command: -G"Ninja"
         - name: Release-Test
           os: ubuntu-22.04

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -61,7 +61,7 @@ jobs:
           binary-path: /build/src/Grazer/grazer
           generator-command: -G"Ninja"
         - name: MacOS-Clang
-          os: macos-latest
+          os: macos-14
           compiler: clang++
           build_type: Debug
           binary-path: /build/src/Grazer/grazer

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ development there.
 ### Installing all dependencies
 
 #### MacOS
+NOTE: There are no automatic checks anymore for macos. I assume that everything
+should run smoothly but I disabled the build tests on mac as I couldn't get them
+to work after the github runners switched to arm mac. The following hints were
+found when someone with a Mac was still contributing to grazer:
 
 On MacOS, the most convenient way to install all of Grazer's dependencies is by
 using [Homebrew](https://brew.sh/). After Homebrew is installed, entering

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# add_compile_options("-march=native")
+add_compile_options("-Wno-switch-default")
 
 add_subdirectory(Model)
 add_subdirectory(Newtonsolver)


### PR DESCRIPTION

googletest defines some macros that have switch statements without explicit defaults. This is (hopefully) fine because they (hopefully) make sure that the default is never reached. But as it happens in a macro, the issue is found when compiling grazer sources and so is triggered even when googletest is linked as a system library. So we ignore this issue in test files but not in the actual source files.